### PR TITLE
Add byebug for debugging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'uglifier'
 gem 'will_paginate'
 
 group :development, :test, :vagrant do
+  gem 'byebug'
   gem 'factory_girl_rails'
   gem 'flog'
   gem 'haml-lint'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,10 @@ GEM
       slim (>= 1.3.6, < 3.0)
       terminal-table (~> 1.4)
     builder (3.2.2)
+    byebug (3.5.1)
+      columnize (~> 0.8)
+      debugger-linecache (~> 1.2)
+      slop (~> 3.6)
     coffee-rails (4.1.0)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
@@ -51,6 +55,8 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.8.0)
+    columnize (0.8.9)
+    debugger-linecache (1.2.0)
     docile (1.1.5)
     erubis (2.7.0)
     execjs (2.2.2)
@@ -187,6 +193,7 @@ PLATFORMS
 
 DEPENDENCIES
   brakeman
+  byebug
   coffee-rails
   factory_girl_rails
   flog


### PR DESCRIPTION
We need to include debugger support since everyone in the team needs it. In future if we decide to use **pry**, it would still need **byebug** to provide debugging support. Thus we have all the more reason to start using byebug right away.
