### PR TITLE
Switch to minitest spec DSL

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ group :development, :test, :vagrant do
   gem 'factory_girl_rails'
   gem 'flog'
   gem 'haml-lint'
+  gem 'minitest-rails'
   gem 'mocha'
   gem 'simplecov'
   gem 'simplecov-rcov'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,6 +118,9 @@ GEM
     mime-types (2.4.3)
     mini_portile (0.6.1)
     minitest (5.4.3)
+    minitest-rails (2.1.1)
+      minitest (~> 5.4)
+      railties (~> 4.1)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     multi_json (1.10.1)
@@ -240,6 +243,7 @@ DEPENDENCIES
   jbuilder
   jquery-rails
   letter_opener
+  minitest-rails
   mocha
   paperclip
   pg

--- a/test/controllers/api_keys_controller_test.rb
+++ b/test/controllers/api_keys_controller_test.rb
@@ -4,277 +4,278 @@ class ApiKeysControllerTest < ActionController::TestCase
   fixtures :accounts
 
   # index action
-  test 'admins should be able to look at the global list of api keys' do
+  it 'admins should be able to look at the global list of api keys' do
     login_as accounts(:admin)
     get :index
-    assert_response :ok
+    must_respond_with :ok
   end
 
-  test 'unlogged in users should not be able to look at the global list of api keys' do
+  it 'unlogged in users should not be able to look at the global list of api keys' do
     login_as nil
     get :index
-    assert_response :unauthorized
+    must_respond_with :unauthorized
   end
 
-  test 'normal users should not be able to look at the global list of api keys' do
+  it 'normal users should not be able to look at the global list of api keys' do
     login_as accounts(:user)
     get :index
-    assert_response :unauthorized
+    must_respond_with :unauthorized
   end
 
-  test 'index page should find models whose name match the "q" parameter' do
+  it 'index page should find models whose name match the "q" parameter' do
     api_key1 = create(:api_key, name: 'foobar')
     api_key2 = create(:api_key, name: 'goobaz')
     login_as accounts(:admin)
     get :index, q: 'foobar'
-    assert_response :ok
-    assert response.body.match(api_key1.name)
-    assert !response.body.match(api_key2.name)
+    must_respond_with :ok
+    response.body.must_match(api_key1.name)
+    response.body.wont_match(api_key2.name)
   end
 
-  test 'index page should find models whose description match the "q" parameter' do
+  it 'index page should find models whose description match the "q" parameter' do
     api_key1 = create(:api_key, description: 'foobar')
     api_key2 = create(:api_key, description: 'goobaz')
     login_as accounts(:admin)
     get :index, q: 'foobar'
-    assert_response :ok
-    assert response.body.match(api_key1.name)
-    assert !response.body.match(api_key2.name)
+    must_respond_with :ok
+    response.body.must_match(api_key1.name)
+    response.body.wont_match(api_key2.name)
   end
 
-  test 'index page should find models whose key match the "q" parameter' do
+  it 'index page should find models whose key match the "q" parameter' do
     api_key1 = create(:api_key, key: 'foobar')
     api_key2 = create(:api_key, key: 'goobaz')
     login_as accounts(:admin)
     get :index, q: 'foobar'
-    assert_response :ok
-    assert response.body.match(api_key1.name)
-    assert !response.body.match(api_key2.name)
+    must_respond_with :ok
+    response.body.must_match(api_key1.name)
+    response.body.wont_match(api_key2.name)
   end
 
-  test 'index page should find models whose account name match the "q" parameter' do
+  it 'index page should find models whose account name match the "q" parameter' do
     api_key1 = create(:api_key, account_id: accounts(:user).id)
     api_key2 = create(:api_key, account_id: accounts(:admin).id)
     login_as accounts(:admin)
     get :index, q: 'user'
-    assert_response :ok
-    assert response.body.match(api_key1.name)
-    assert !response.body.match(api_key2.name)
+    must_respond_with :ok
+    response.body.must_match(api_key1.name)
+    response.body.wont_match(api_key2.name)
   end
 
-  test 'index page should accept "query" in place of "q" as a parameter' do
+  it 'index page should accept "query" in place of "q" as a parameter' do
     api_key1 = create(:api_key, name: 'foobar')
     api_key2 = create(:api_key, name: 'goobaz')
     login_as accounts(:admin)
     get :index, query: 'foobar'
-    assert_response :ok
-    assert response.body.match(api_key1.name)
-    assert !response.body.match(api_key2.name)
+    must_respond_with :ok
+    response.body.must_match(api_key1.name)
+    response.body.wont_match(api_key2.name)
   end
 
-  test 'index page should honor the sort order "most_recent_request"' do
+  it 'index page should honor the sort order "most_recent_request"' do
     api_key1 = create(:api_key, last_access_at: Time.now)
     api_key2 = create(:api_key, last_access_at: Time.now - 1.day)
     api_key3 = create(:api_key, last_access_at: Time.now + 1.day)
     login_as accounts(:admin)
     get :index, sort: 'most_recent_request'
-    assert_response :ok
-    assert(/#{api_key3.name}.*#{api_key1.name}.*#{api_key2.name}/m.match(response.body))
+    must_respond_with :ok
+    response.body.must_match(/#{api_key3.name}.*#{api_key1.name}.*#{api_key2.name}/m)
   end
 
-  test 'index page should honor the sort order "most_requests_today"' do
+  it 'index page should honor the sort order "most_requests_today"' do
     api_key1 = create(:api_key, daily_count: 11)
     api_key2 = create(:api_key, daily_count: 10)
     api_key3 = create(:api_key, daily_count: 12)
     login_as accounts(:admin)
     get :index, sort: 'most_requests_today'
-    assert_response :ok
-    assert(/#{api_key3.name}.*#{api_key1.name}.*#{api_key2.name}/m.match(response.body))
+    must_respond_with :ok
+    response.body.must_match(/#{api_key3.name}.*#{api_key1.name}.*#{api_key2.name}/m)
   end
 
-  test 'index page should honor the sort order "most_requests"' do
+  it 'index page should honor the sort order "most_requests"' do
     api_key1 = create(:api_key, total_count: 11)
     api_key2 = create(:api_key, total_count: 10)
     api_key3 = create(:api_key, total_count: 12)
     login_as accounts(:admin)
     get :index, sort: 'most_requests'
-    assert_response :ok
-    assert(/#{api_key3.name}.*#{api_key1.name}.*#{api_key2.name}/m.match(response.body))
+    must_respond_with :ok
+    response.body.must_match(/#{api_key3.name}.*#{api_key1.name}.*#{api_key2.name}/m)
   end
 
-  test 'index page should honor the sort order "newest"' do
+  it 'index page should honor the sort order "newest"' do
     api_key1 = create(:api_key, created_at: Time.now)
     api_key2 = create(:api_key, created_at: Time.now - 1.day)
     api_key3 = create(:api_key, created_at: Time.now + 1.day)
     login_as accounts(:admin)
     get :index, sort: 'newest'
-    assert_response :ok
-    assert(/#{api_key3.name}.*#{api_key1.name}.*#{api_key2.name}/m.match(response.body))
+    must_respond_with :ok
+    response.body.must_match(/#{api_key3.name}.*#{api_key1.name}.*#{api_key2.name}/m)
   end
 
-  test 'index page should honor the sort order "oldest"' do
+  it 'index page should honor the sort order "oldest"' do
     api_key1 = create(:api_key, created_at: Time.now)
     api_key2 = create(:api_key, created_at: Time.now - 1.day)
     api_key3 = create(:api_key, created_at: Time.now + 1.day)
     login_as accounts(:admin)
     get :index, sort: 'oldest'
-    assert_response :ok
-    assert(/#{api_key2.name}.*#{api_key1.name}.*#{api_key3.name}/m.match(response.body))
+    must_respond_with :ok
+    response.body.must_match(/#{api_key2.name}.*#{api_key1.name}.*#{api_key3.name}/m)
   end
 
-  test 'index page should honor the sort order "account_name"' do
+  it 'index page should honor the sort order "account_name"' do
     api_key1 = create(:api_key, account_id: accounts(:user).id)
     api_key2 = create(:api_key, account_id: accounts(:admin).id)
     login_as accounts(:admin)
     get :index, sort: 'account_name'
-    assert_response :ok
-    assert(/#{api_key2.name}.*#{api_key1.name}/m.match(response.body))
+    must_respond_with :ok
+    response.body.must_match(/#{api_key2.name}.*#{api_key1.name}/m)
   end
 
-  test 'index page should assume "newest" when the sort parameter is unsupported' do
+  it 'index page should assume "newest" when the sort parameter is unsupported' do
     api_key1 = create(:api_key, created_at: Time.now)
     api_key2 = create(:api_key, created_at: Time.now - 1.day)
     api_key3 = create(:api_key, created_at: Time.now + 1.day)
     login_as accounts(:admin)
     get :index, sort: 'I_am_a_banana!'
-    assert_response :ok
-    assert(/#{api_key3.name}.*#{api_key1.name}.*#{api_key2.name}/m.match(response.body))
+    must_respond_with :ok
+    response.body.must_match(/#{api_key3.name}.*#{api_key1.name}.*#{api_key2.name}/m)
   end
 
-  test 'admins should be able to look at the api keys of someone else' do
+  it 'admins should be able to look at the api keys of someone else' do
     login_as accounts(:admin)
     get :index, account_id: accounts(:user).id
-    assert_response :ok
+    must_respond_with :ok
   end
 
-  test 'unlogged in users should not be able to look at the api keys of a user' do
+  it 'unlogged in users should not be able to look at the api keys of a user' do
     login_as nil
     get :index, account_id: accounts(:user).id
-    assert_response :unauthorized
+    must_respond_with :unauthorized
   end
 
-  test 'normal users should be able to look at their own api keys' do
+  it 'normal users should be able to look at their own api keys' do
     login_as accounts(:user)
     get :index, account_id: accounts(:user).id
-    assert_response :ok
+    must_respond_with :ok
   end
 
-  test 'normal users should not be able to look at someone elses api keys' do
+  it 'normal users should not be able to look at someone elses api keys' do
     login_as accounts(:user)
     get :index, account_id: accounts(:admin).id
-    assert_response :unauthorized
+    must_respond_with :unauthorized
   end
 
-  test 'normal users should see their api keys, but not others' do
+  it 'normal users should see their api keys, but not others' do
     api_key1 = create(:api_key, account_id: accounts(:user).id)
     api_key2 = create(:api_key, account_id: accounts(:admin).id)
     login_as accounts(:user)
     get :index, account_id: accounts(:user).id
-    assert_response :ok
-    assert response.body.match(api_key1.name)
-    assert !response.body.match(api_key2.name)
+    must_respond_with :ok
+    response.body.must_match(api_key1.name)
+    response.body.wont_match(api_key2.name)
   end
 
-  test 'admins should be able to download a csv of the global list of api keys' do
+  it 'admins should be able to download a csv of the global list of api keys' do
     api_key1 = create(:api_key, account_id: accounts(:user).id)
     api_key2 = create(:api_key, account_id: accounts(:admin).id)
     login_as accounts(:admin)
     get :index, format: :csv
-    assert_response :ok
-    assert response.body.match('Open Hub account,Application Name')
-    assert response.body.match(api_key1.name)
-    assert response.body.match(api_key2.name)
-    assert response.headers['Content-Type'].include? 'text/csv'
-    assert response.headers['Content-Disposition'].include? 'attachment'
-    assert response.headers['Content-Disposition'].include? 'api_keys_report.csv'
+    must_respond_with :ok
+    response.body.must_match('Open Hub account,Application Name')
+    response.body.must_match(api_key1.name)
+    response.body.must_match(api_key2.name)
+    response.headers['Content-Type'].must_include('text/csv')
+    response.headers['Content-Type'].must_include('text/csv')
+    response.headers['Content-Disposition'].must_include('attachment')
+    response.headers['Content-Disposition'].must_include('api_keys_report.csv')
   end
 
   # new action
-  test 'new should let admins edit daily limit' do
+  it 'new should let admins edit daily limit' do
     login_as accounts(:admin)
     get :new, account_id: accounts(:admin).id
-    assert_response :ok
-    assert response.body.match('api_key_daily_limit')
+    must_respond_with :ok
+    response.body.must_match('api_key_daily_limit')
   end
 
-  test 'new should not let users edit daily limit' do
+  it 'new should not let users edit daily limit' do
     login_as accounts(:user)
     get :new, account_id: accounts(:user).id
-    assert_response :ok
-    assert !response.body.match('api_key_daily_limit')
+    must_respond_with :ok
+    response.body.wont_match('api_key_daily_limit')
   end
 
-  test 'new should not let users who have enough keys make more' do
+  it 'new should not let users who have enough keys make more' do
     (1..ApiKey::KEY_LIMIT_PER_ACCOUNT).each { create(:api_key, account_id: accounts(:user).id) }
     login_as accounts(:user)
     get :new, account_id: accounts(:user).id
-    assert_response 302
+    must_respond_with 302
   end
 
   # create action
-  test 'create with valid parameters should create an api key' do
+  it 'create with valid parameters should create an api key' do
     login_as accounts(:user)
     post :create, account_id: accounts(:user).id, api_key: { name: 'Name',
                                                              description: 'It was the best of times.',
                                                              terms: '1' }
-    assert_response :found
-    assert ApiKey.where(account_id: accounts(:user).id, description: 'It was the best of times.').first
+    must_respond_with :found
+    ApiKey.where(account_id: accounts(:user).id, description: 'It was the best of times.').first.must_be :present?
   end
 
-  test 'create requires accepting the terms of service' do
+  it 'create requires accepting the terms of service' do
     login_as accounts(:user)
     post :create, account_id: accounts(:user).id, api_key: { name: 'Name',
                                                              description: 'I do not accept those terms!',
                                                              terms: '0' }
-    assert_response :bad_request
-    assert response.body.match(I18n.t(:must_accept_terms))
-    assert !ApiKey.where(account_id: accounts(:user).id, description: 'I do not accept those terms!').first
+    must_respond_with :bad_request
+    response.body.must_match(I18n.t(:must_accept_terms))
+    ApiKey.where(account_id: accounts(:user).id, description: 'I do not accept those terms!').first.wont_be :present?
   end
 
   # edit action
-  test 'edit should populate the form' do
+  it 'edit should populate the form' do
     api_key = create(:api_key, account_id: accounts(:user).id, description: 'A pre-existing API Key.')
     login_as accounts(:user)
     get :edit, account_id: accounts(:user).id, id: api_key.id
-    assert_response :ok
-    assert response.body.match('A pre-existing API Key.')
+    must_respond_with :ok
+    response.body.must_match('A pre-existing API Key.')
   end
 
-  test 'edit should 404 attempting to edit a non-existant api key' do
+  it 'edit should 404 attempting to edit a non-existant api key' do
     login_as accounts(:user)
     get :edit, account_id: accounts(:user).id, id: 9876
-    assert_response :not_found
+    must_respond_with :not_found
   end
 
   # update action
-  test 'update should populate the form' do
+  it 'update should populate the form' do
     api_key = create(:api_key, account_id: accounts(:user).id, description: 'My old crufty API Key.')
     login_as accounts(:user)
     put :update, account_id: accounts(:user).id, id: api_key.id, api_key: { name: 'Name',
                                                                             description: 'Repolished key!',
                                                                             terms: '1' }
-    assert_response 302
+    must_respond_with 302
     api_key.reload
-    assert_equal 'Repolished key!', api_key.description
+    api_key.description.must_equal 'Repolished key!'
   end
 
-  test 'update does not allow unaccepting the terms' do
+  it 'update does not allow unaccepting the terms' do
     api_key = create(:api_key, account_id: accounts(:user).id, description: 'My previous API Key.')
     login_as accounts(:user)
     put :update, account_id: accounts(:user).id, id: api_key.id, api_key: { name: 'Name',
                                                                             description: 'I cleverly unaccept now!',
                                                                             terms: '0' }
-    assert_response :bad_request
+    must_respond_with :bad_request
     api_key.reload
-    assert_equal 'My previous API Key.', api_key.description
+    api_key.description.must_equal 'My previous API Key.'
   end
 
   # destroy action
-  test 'destroy should remove the api key from the db' do
+  it 'destroy should remove the api key from the db' do
     api_key = create(:api_key, account_id: accounts(:user).id, description: 'My doomed key.')
     login_as accounts(:user)
     delete :destroy, account_id: accounts(:user).id, id: api_key.id
-    assert_response 302
-    assert !ApiKey.where(account_id: accounts(:user).id, description: 'My doomed key.').first
+    must_respond_with 302
+    ApiKey.where(account_id: accounts(:user).id, description: 'My doomed key.').first.wont_be :present?
   end
 end

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -11,76 +11,76 @@ class ApplicationControllerTest < ActionController::TestCase
 
   test 'render_404 as html' do
     get :renders_404
-    assert_response :not_found
-    assert response.body.include? I18n.t(:four_oh_four)
-    assert response.headers['Content-Type'].include? 'text/html'
+    must_respond_with :not_found
+    response.body.must_include(I18n.t(:four_oh_four))
+    response.headers['Content-Type'].must_include('text/html')
   end
 
   test 'render_404 as json' do
     get :renders_404, format: 'json'
-    assert_response :not_found
-    assert response.body.include? I18n.t(:four_oh_four)
-    assert response.headers['Content-Type'].include? 'application/json'
+    must_respond_with :not_found
+    response.body.must_include(I18n.t(:four_oh_four))
+    response.headers['Content-Type'].must_include('application/json')
   end
 
   test 'render_404 as xml' do
     get :renders_404, format: 'xml'
-    assert_response :not_found
-    assert response.body.include? I18n.t(:four_oh_four)
-    assert response.headers['Content-Type'].include? 'application/xml'
+    must_respond_with :not_found
+    response.body.must_include(I18n.t(:four_oh_four))
+    response.headers['Content-Type'].must_include('application/xml')
   end
 
   test 'error message as html' do
     get :error_with_message
-    assert_response :unauthorized
-    assert response.body.include? 'test error string'
+    must_respond_with :unauthorized
+    response.body.must_include('test error string')
   end
 
   test 'error message as json' do
     get :error_with_message, format: 'json'
-    assert_response :unauthorized
-    assert response.body.include? 'test error string'
+    must_respond_with :unauthorized
+    response.body.must_include('test error string')
   end
 
   test 'error message as xml' do
     get :error_with_message, format: 'xml'
-    assert_response :unauthorized
-    assert response.body.include? 'test error string'
+    must_respond_with :unauthorized
+    response.body.must_include('test error string')
   end
 
   test 'session_required with a current user' do
     login_as accounts(:user)
     get :session_required_action
-    assert_response :ok
+    must_respond_with :ok
   end
 
   test 'session_required without a current user' do
     login_as nil
     get :session_required_action
-    assert_response :unauthorized
+    must_respond_with :unauthorized
   end
 
   test 'admin_session_required with a current admin' do
     login_as accounts(:admin)
     get :admin_session_required_action
-    assert_response :ok
+    must_respond_with :ok
   end
 
   test 'admin_session_required without a current user' do
     login_as nil
     get :admin_session_required_action
-    assert_response :unauthorized
+    must_respond_with :unauthorized
   end
 
   test 'admin_session_required with a current plain user' do
     login_as accounts(:user)
     get :admin_session_required_action
-    assert_response :unauthorized
+    must_respond_with :unauthorized
   end
 
   test 'ParamRecordNotFound exceptions are caught and not passed on as 500s' do
     get :throws_param_record_not_found
-    assert_response :not_found
+    must_respond_with :not_found
   end
 
   test 'remember me functionality automatically logs users in' do
@@ -89,8 +89,8 @@ class ApplicationControllerTest < ActionController::TestCase
     Authenticator.remember(admin)
     @request.cookies[:auth_token] = admin.remember_token
     get :session_required_action
-    assert_response :ok
-    assert_equal admin.id, session[:account_id]
+    must_respond_with :ok
+    session[:account_id].must_equal admin.id
   end
 end
 

--- a/test/controllers/helpfuls_controller_test.rb
+++ b/test/controllers/helpfuls_controller_test.rb
@@ -6,76 +6,76 @@ class HelpfulsControllerTest < ActionController::TestCase
     @linux_review = projects(:linux).reviews.create!(title: 'T', comment: 'C', account_id: accounts(:admin).id)
   end
 
-  def test_login_required
+  it 'test login required' do
     login_as nil
     create_helpful(true)
-    assert_response :unauthorized
+    must_respond_with :unauthorized
   end
 
-  def test_create_review_helpful
+  it 'test create review helpful' do
     login_as accounts(:user)
     assert_difference 'Helpful.count' do
       create_helpful(true)
-      assert_response :success
+      must_respond_with :success
       json = JSON.parse(@response.body)
-      assert_equal 1, json['yes']
-      assert_equal 1, json['total']
+      json['yes'].must_equal 1
+      json['total'].must_equal 1
     end
   end
 
-  def test_create_review_not_helpful
+  it 'test create review not helpful' do
     login_as accounts(:user)
     assert_difference 'Helpful.count' do
       create_helpful(false)
-      assert_response :success
+      must_respond_with :success
       json = JSON.parse(@response.body)
-      assert_equal 0, json['yes']
-      assert_equal 1, json['total']
+      json['yes'].must_equal 0
+      json['total'].must_equal 1
     end
   end
 
-  def test_bug_fix_on_multiple_helpfuls
+  it 'test bug fix on multiple helpfuls' do
     Helpful.create(review_id: @linux_review.id, account_id: accounts(:user).id, yes: false)
     login_as accounts(:joe)
     assert_difference 'Helpful.count' do
       create_helpful(true)
-      assert_response :success
+      must_respond_with :success
       json = JSON.parse(@response.body)
-      assert_equal 1, json['yes']
-      assert_equal 2, json['total']
+      json['yes'].must_equal 1
+      json['total'].must_equal 2
     end
   end
 
-  def test_cant_helpful_yourself
+  it 'test cant helpful yourself' do
     login_as accounts(:admin)
     assert_no_difference 'Helpful.count' do
       create_helpful(true)
-      assert_response :success
+      must_respond_with :success
       json = JSON.parse(@response.body)
-      assert_equal 0, json['yes']
-      assert_equal 0, json['total']
+      json['yes'].must_equal 0
+      json['total'].must_equal 0
     end
   end
 
-  def test_project_must_exist
+  it 'test project must exist' do
     login_as accounts(:user)
     post :create, project_id: 'I_AM_A_BANANA!', review_id: @linux_review.id,
                   format: 'json', helpful: { yes: true }
-    assert_response :not_found
+    must_respond_with :not_found
   end
 
-  def test_review_must_exist
+  it 'test review must exist' do
     login_as accounts(:user)
     post :create, project_id: projects(:linux).to_param, review_id: 123_456_789,
                   format: 'json', helpful: { yes: true }
-    assert_response :not_found
+    must_respond_with :not_found
   end
 
-  def test_review_must_match_project
+  it 'test review must match project' do
     login_as accounts(:user)
     post :create, project_id: projects(:adium).to_param, review_id: @linux_review.id,
                   format: 'json', helpful: { yes: true }
-    assert_response :not_found
+    must_respond_with :not_found
   end
 
   private

--- a/test/controllers/logos_controller_test.rb
+++ b/test/controllers/logos_controller_test.rb
@@ -9,73 +9,73 @@ class LogosControllerTest < ActionController::TestCase
     @user = accounts(:user)
   end
 
-  test 'user has permissions to edit' do
+  it 'user has permissions to edit' do
     # TODO: acts_as_edited
     Project.any_instance.expects(:edit_authorized?).returns(false)
     login_as @user
     post :create, project_id: projects(:linux).id
-    assert_response :redirect
-    assert_redirected_to '/sessions/new'
+    must_respond_with :redirect
+    must_redirect_to '/sessions/new'
   end
 
-  test 'upload logo via URL' do
+  it 'upload logo via URL' do
     login_as @admin
     project = projects(:linux)
     Project.any_instance.expects(:edit_authorized?).returns(true)
     post :create, project_id: project.id, logo: { url: 'https://www.openhub.net/images/clear.gif' }
-    assert_redirected_to new_project_logos_path
-    assert_equal project.reload.logo.attachment_file_name, 'clear.gif'
-    assert_equal project.logo.attachment_content_type, 'image/gif'
+    must_redirect_to new_project_logos_path
+    project.reload.logo.attachment_file_name.must_equal 'clear.gif'
+    project.logo.attachment_content_type.must_equal 'image/gif'
   end
 
-  test 'upload logo for organization via URL' do
+  it 'upload logo for organization via URL' do
     login_as @admin
     organization = organizations(:linux)
     Organization.any_instance.expects(:edit_authorized?).returns(true)
     post :create, organization_id: organization.id, logo: { url: 'https://www.openhub.net/images/clear.gif' }
-    assert_redirected_to new_organization_logos_path
-    assert_equal organization.reload.logo.attachment_file_name, 'clear.gif'
-    assert_equal organization.logo.attachment_content_type, 'image/gif'
+    must_redirect_to new_organization_logos_path
+    organization.reload.logo.attachment_file_name.must_equal 'clear.gif'
+    organization.logo.attachment_content_type.must_equal 'image/gif'
   end
 
-  test 'validate failure'do
+  it 'validate failure'do
     login_as @admin
     project = projects(:linux)
     Project.any_instance.expects(:edit_authorized?).returns(true)
     post :create, project_id: project.id, logo: { url: 'https://www.dummyhost.net/images/clear.gif' }
-    assert_redirected_to new_project_logos_path
-    assert_equal 'Sorry, there was a problem updating the logo', flash[:error]
+    must_redirect_to new_project_logos_path
+    flash[:error].must_equal 'Sorry, there was a problem updating the logo'
   end
 
-  test 'upload logo via desktop file' do
+  it 'upload logo via desktop file' do
     login_as @admin
     project = projects(:linux)
     Project.any_instance.expects(:edit_authorized?).returns(true)
     tempfile = Rack::Test::UploadedFile.new('test/fixtures/files/ruby.png', 'image/png')
     post :create, project_id: project.id, logo: { attachment: tempfile }
-    assert_redirected_to new_project_logos_path
-    assert_equal project.reload.logo.attachment_file_name, 'ruby.png'
-    assert_equal project.logo.attachment_content_type, 'image/png'
+    must_redirect_to new_project_logos_path
+    project.reload.logo.attachment_file_name.must_equal 'ruby.png'
+    project.logo.attachment_content_type.must_equal 'image/png'
   end
 
-  test 'open LogosController new for project with no logo renders successfully' do
+  it 'open LogosController new for project with no logo renders successfully' do
     project = projects(:linux)
 
     get :new, project_id: project.id
-    assert_response :success
+    must_respond_with :success
   end
 
-  test 'LogosController destroy resets to NilLogo' do
+  it 'LogosController destroy resets to NilLogo' do
     project = projects(:linux)
     login_as @admin
 
     delete :destroy, project_id: project.id
 
-    assert_redirected_to new_project_logos_path
-    assert_equal NilClass, project.reload.logo.class
+    must_redirect_to new_project_logos_path
+    NilClass.must_equal project.reload.logo.class
   end
 
-  test 'new logos page for a deleted project is rendered using the projects/deleted template' do
+  it 'new logos page for a deleted project is rendered using the projects/deleted template' do
     skip('TODO: projects')
     project = projects(:linux)
 
@@ -85,27 +85,27 @@ class LogosControllerTest < ActionController::TestCase
 
     get :new, project_id: project.id
 
-    assert_response :success
-    assert_template 'projects/deleted'
+    must_respond_with :success
+    must_render_template 'projects/deleted'
   end
 
-  test 'new unauthenticated' do
+  it 'new unauthenticated' do
     get :new, project_id: projects(:linux).id
-    assert_response :success
+    must_respond_with :success
   end
 
-  test 'new' do
+  it 'new' do
     skip('TODO: application')
     login_as @admin
     get :new, project_id: projects(:linux).id
-    assert_response :success
-    assert_select 'form[action=?]', project_logos_path do
+    must_respond_with :success
+    'form[action=?]'.must_select project_logos_path do
       assert_select 'input[type=radio][name=logo_id]'
       assert_select 'input[type=submit]'
     end
   end
 
-  test 'new shows flash if user has no permissions' do
+  it 'new shows flash if user has no permissions' do
     skip('TODO: manage')
     with_editor :jason do
       Manage.create!(project: projects(:linux), account: accounts(:robin))
@@ -114,21 +114,21 @@ class LogosControllerTest < ActionController::TestCase
 
     login_as @user
     get :new, project_id: projects(:linux).id
-    assert_equal 'You can view, but not change this data. Only managers may change this data.', flash[:notice]
+    flash[:notice].must_equal 'You can view, but not change this data. Only managers may change this data.'
   end
 
-  test 'create with logo id' do
+  it 'create with logo id' do
     # TODO: acts_as_edited
     login_as @admin
     Project.any_instance.expects(:edit_authorized?).returns(true)
     desired_new_logo_id = attachments(:random_logo).id
     post :create, project_id: projects(:linux).id, logo_id: desired_new_logo_id
-    assert_redirected_to new_project_logos_path(projects(:linux).id)
+    must_redirect_to new_project_logos_path(projects(:linux).id)
     projects(:linux).reload
-    assert_equal desired_new_logo_id, projects(:linux).logo_id
+    desired_new_logo_id.must_equal projects(:linux).logo_id
   end
 
-  test 'create requires permissions' do
+  it 'create requires permissions' do
     skip('TODO: manage')
     with_editor :jason do
       Manage.create!(project: projects(:linux), account: accounts(:robin))
@@ -140,7 +140,7 @@ class LogosControllerTest < ActionController::TestCase
     assert_no_difference('projects(:linux).reload.logo_id') do
       post :create, project_id: projects(:linux).id, logo_id: desired_new_logo_id
     end
-    assert_redirected_to new_session_path
-    assert flash[:error] =~ /authorized/
+    must_redirect_to new_session_path
+    flash[:error].must_match(/authorized/)
   end
 end

--- a/test/controllers/permissions_controller_test.rb
+++ b/test/controllers/permissions_controller_test.rb
@@ -9,100 +9,100 @@ class PermissionsControllerTest < ActionController::TestCase
   end
 
   # show action
-  test 'unlogged users should see permissions alert' do
+  it 'unlogged users should see permissions alert' do
     login_as nil
     get :show, id: @project
-    assert_response :ok
-    assert response.body.include?(I18n.t('permissions.must_log_in'))
-    assert_tag tag: 'input', attributes: { disabled: 'disabled' }
+    must_respond_with :ok
+    response.body.must_include(I18n.t('permissions.must_log_in'))
+    must_have_tag tag: 'input', attributes: { disabled: 'disabled' }
   end
 
-  test 'admins should not see permissions alert' do
+  it 'admins should not see permissions alert' do
     login_as accounts(:admin)
     get :show, id: @project
-    assert_response :ok
-    assert !response.body.include?('flash-msg')
-    assert_no_tag tag: 'input', attributes: { disabled: 'disabled' }
+    must_respond_with :ok
+    response.body.wont_include('flash-msg')
+    wont_have_tag tag: 'input', attributes: { disabled: 'disabled' }
   end
 
-  test 'non-managers should see permissions alert' do
+  it 'non-managers should see permissions alert' do
     login_as accounts(:user)
     get :show, id: @project
-    assert_response :ok
-    assert response.body.include?(I18n.t('permissions.not_manager'))
-    assert_tag tag: 'input', attributes: { disabled: 'disabled' }
+    must_respond_with :ok
+    response.body.must_include(I18n.t('permissions.not_manager'))
+    must_have_tag tag: 'input', attributes: { disabled: 'disabled' }
   end
 
-  test 'managers pending approval should see permissions alert' do
+  it 'managers pending approval should see permissions alert' do
     Manage.create(target: @project, account_id: accounts(:admin).id) # auto-approved
     Manage.create(target: @project, account_id: accounts(:user).id) # pending approval
     login_as accounts(:user)
     get :show, id: @project
-    assert_response :ok
-    assert response.body.include?(I18n.t('permissions.not_manager'))
-    assert_tag tag: 'input', attributes: { disabled: 'disabled' }
+    must_respond_with :ok
+    response.body.must_include(I18n.t('permissions.not_manager'))
+    must_have_tag tag: 'input', attributes: { disabled: 'disabled' }
   end
 
-  test 'approved managers should not see permissions alert' do
+  it 'approved managers should not see permissions alert' do
     login_as accounts(:user)
     Manage.create(target: @project, account_id: accounts(:user).id, approved_by: accounts(:admin).id)
     get :show, id: @project
-    assert_response :ok
-    assert !response.body.include?('flash-msg')
-    assert_no_tag tag: 'input', attributes: { disabled: 'disabled' }
+    must_respond_with :ok
+    response.body.wont_include('flash-msg')
+    wont_have_tag tag: 'input', attributes: { disabled: 'disabled' }
   end
 
-  test 'should gracefully handle non-existent projects' do
+  it 'should gracefully handle non-existent projects' do
     login_as nil
     get :show, id: 'i_am_a_banana'
-    assert_response :not_found
+    must_respond_with :not_found
   end
 
   # update action
-  test 'unlogged users should 401' do
+  it 'unlogged users should 401' do
     login_as nil
     put :update, id: @project, permission: { remainder: true }
-    assert_response :unauthorized
+    must_respond_with :unauthorized
   end
 
-  test 'admins should be able to update the permissions' do
+  it 'admins should be able to update the permissions' do
     login_as accounts(:admin)
     put :update, id: @project, permission: { remainder: true }
     @permissions.reload
-    assert_response :ok
-    assert_equal true, @permissions.remainder
+    must_respond_with :ok
+    @permissions.remainder.must_equal true
   end
 
-  test 'non-managers should 401' do
+  it 'non-managers should 401' do
     login_as accounts(:user)
     put :update, id: @project, permission: { remainder: true }
-    assert_response :unauthorized
+    must_respond_with :unauthorized
   end
 
-  test 'managers pending approval should 401' do
+  it 'managers pending approval should 401' do
     Manage.create(target: @project, account_id: accounts(:admin).id) # auto-approved
     Manage.create(target: @project, account_id: accounts(:user).id) # pending approval
     login_as accounts(:user)
     put :update, id: @project, permission: { remainder: true }
-    assert_response :unauthorized
+    must_respond_with :unauthorized
   end
 
-  test 'approved managers should be able to update the permissions' do
+  it 'approved managers should be able to update the permissions' do
     login_as accounts(:user)
     Manage.create(target: @project, account_id: accounts(:user).id, approved_by: accounts(:admin).id)
     put :update, id: @project, permission: { remainder: true }
     @permissions.reload
-    assert_response :ok
-    assert_equal true, @permissions.remainder
+    must_respond_with :ok
+    @permissions.remainder.must_equal true
   end
 
-  test 'save failures should 422' do
+  it 'save failures should 422' do
     login_as accounts(:user)
     Manage.create(target: @project, account_id: accounts(:user).id, approved_by: accounts(:admin).id)
     Permission.any_instance.expects(:update).returns false
     put :update, id: @project, permission: { remainder: true }
     @permissions.reload
-    assert_response :unprocessable_entity
-    assert_equal false, @permissions.remainder
+    must_respond_with :unprocessable_entity
+    @permissions.remainder.must_equal false
   end
 end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -4,82 +4,82 @@ class SessionsControllerTest < ActionController::TestCase
   fixtures :accounts
 
   # new action
-  test 'the new action should render correctly' do
+  it 'the new action should render correctly' do
     get :new
-    assert_response :ok
+    must_respond_with :ok
   end
 
   # create action
-  test 'create with valid credentials should log in' do
-    assert_equal nil, session[:account_id]
+  it 'create with valid credentials should log in' do
+    session[:account_id].must_be_nil
     post :create, login: { login: 'admin', password: 'test' }
-    assert_response :found
-    assert_equal accounts(:admin).id, session[:account_id]
-    assert_equal I18n.t('sessions.create.success'), flash[:notice]
+    must_respond_with :found
+    session[:account_id].must_equal accounts(:admin).id
+    flash[:notice].must_equal I18n.t('sessions.create.success')
   end
 
-  test 'create with invalid credentials should not log in' do
-    assert_equal nil, session[:account_id]
+  it 'create with invalid credentials should not log in' do
+    session[:account_id].must_be_nil
     post :create, login: { login: 'admin', password: 'not the password' }
-    assert_response :bad_request
-    assert_equal nil, session[:account_id]
-    assert_equal I18n.t('sessions.create.error'), flash[:error]
+    must_respond_with :bad_request
+    session[:account_id].must_be_nil
+    flash[:error].must_equal I18n.t('sessions.create.error')
   end
 
-  test 'create with valid credentials for disabled accounts should not log in' do
-    assert_equal nil, session[:account_id]
+  it 'create with valid credentials for disabled accounts should not log in' do
+    session[:account_id].must_be_nil
     post :create, login: { login: 'sir_spams_a_lot', password: 'test' }
-    assert_response :bad_request
-    assert_equal nil, session[:account_id]
-    assert_equal I18n.t('sessions.create.disabled_error'), flash[:error]
+    must_respond_with :bad_request
+    session[:account_id].must_be_nil
+    flash[:error].must_equal I18n.t('sessions.create.disabled_error')
   end
 
-  test 'create with valid credentials for unactivated accounts should not log in' do
-    assert_equal nil, session[:account_id]
+  it 'create with valid credentials for unactivated accounts should not log in' do
+    session[:account_id].must_be_nil
     post :create, login: { login: 'unactivated', password: 'testy' }
-    assert_response :bad_request
-    assert_equal nil, session[:account_id]
-    assert_equal I18n.t('sessions.create.unactivated_error'), flash[:error]
+    must_respond_with :bad_request
+    session[:account_id].must_be_nil
+    flash[:error].must_equal I18n.t('sessions.create.unactivated_error')
   end
 
-  test 'create with remember me set should save the right data to the account and cookies' do
+  it 'create with remember me set should save the right data to the account and cookies' do
     admin = accounts(:admin)
-    assert_nil admin.remember_token
-    assert_nil admin.remember_token_expires_at
+    admin.remember_token.must_be_nil
+    admin.remember_token_expires_at.must_be_nil
     post :create, login: { login: 'admin', password: 'test', remember_me: '1' }
-    assert_response :found
+    must_respond_with :found
     admin.reload
-    assert_not_nil admin.remember_token
-    assert_not_nil admin.remember_token_expires_at
-    assert_equal admin.remember_token, cookies[:auth_token]
+    admin.remember_token.wont_be_nil
+    admin.remember_token_expires_at.wont_be_nil
+    cookies[:auth_token].must_equal admin.remember_token
   end
 
-  test 'create should inform uninformed users about privacy' do
-    assert_equal nil, session[:account_id]
+  it 'create should inform uninformed users about privacy' do
+    session[:account_id].must_be_nil
     post :create, login: { login: 'privacy', password: 'test' }
-    assert_response :found
-    assert_equal accounts(:not_privacy_informed).id, session[:account_id]
-    assert_equal I18n.t('sessions.create.learn_about_privacy'), flash[:notice]
+    must_respond_with :found
+    session[:account_id].must_equal accounts(:not_privacy_informed).id
+    flash[:notice].must_equal I18n.t('sessions.create.learn_about_privacy')
   end
 
   # destroy action
-  test 'destroy should log out' do
+  it 'destroy should log out' do
     session[:account_id] = accounts(:admin).id
     delete :destroy
-    assert_response :found
-    assert_equal nil, session[:account_id]
-    assert_equal I18n.t('sessions.destroy.success'), flash[:notice]
+    must_respond_with :found
+    session[:account_id].must_be_nil
+    flash[:notice].must_equal I18n.t('sessions.destroy.success')
   end
 
-  test 'destroy should clear remember me data' do
+  it 'destroy should clear remember me data' do
     admin = accounts(:admin)
     Authenticator.remember(admin)
     session[:account_id] = accounts(:admin).id
     delete :destroy
-    assert_response :found
+    must_respond_with :found
     admin.reload
-    assert_nil admin.remember_token
-    assert_nil admin.remember_token_expires_at
-    assert_equal admin.remember_token, cookies[:auth_token]
+    admin.remember_token.must_be_nil
+    admin.remember_token_expires_at.must_be_nil
+    cookies[:auth_token].must_equal admin.remember_token
   end
 end

--- a/test/core_extensions/ruby/string_test.rb
+++ b/test/core_extensions/ruby/string_test.rb
@@ -2,49 +2,49 @@
 require 'test_helper'
 
 class StringTest < ActiveSupport::TestCase
-  test 'strip_tags' do
-    assert_equal '', ''.strip_tags
-    assert_equal 'test', 'test'.strip_tags
-    assert_equal 'XY', 'X<br/>Y'.strip_tags
-    assert_equal 'XY', '<p>X</p>Y'.strip_tags
-    assert_equal 'X', '<p>X</p>'.strip_tags
-    assert_equal 'XYZ', "X<a href='#'>Y</a>Z".strip_tags
-    assert_equal 'XYZ', 'X<h1>Y</h2>Z'.strip_tags
-    assert_equal 'X<Y', 'X<Y'.strip_tags
-    assert_equal 'X>Y', 'X>Y'.strip_tags
-    assert_equal 'X&gt;Y', 'X&gt;Y'.strip_tags
-    assert_equal 'X&lt;Y', 'X&lt;Y'.strip_tags
-    assert_equal 'X&amp;Y', 'X&amp;Y'.strip_tags
+  it 'strip tags' do
+    ''.strip_tags.must_equal ''
+    'test'.strip_tags.must_equal 'test'
+    'X<br/>Y'.strip_tags.must_equal 'XY'
+    '<p>X</p>Y'.strip_tags.must_equal 'XY'
+    '<p>X</p>'.strip_tags.must_equal 'X'
+    "X<a href='#'>Y</a>Z".strip_tags.must_equal 'XYZ'
+    'X<h1>Y</h2>Z'.strip_tags.must_equal 'XYZ'
+    'X<Y'.strip_tags.must_equal 'X<Y'
+    'X>Y'.strip_tags.must_equal 'X>Y'
+    'X&gt;Y'.strip_tags.must_equal 'X&gt;Y'
+    'X&lt;Y'.strip_tags.must_equal 'X&lt;Y'
+    'X&amp;Y'.strip_tags.must_equal 'X&amp;Y'
   end
 
-  test 'strip_tags_preserve_line_breaks' do
-    assert_equal '', ''.strip_tags_preserve_line_breaks
-    assert_equal 'test', 'test'.strip_tags_preserve_line_breaks
+  it 'strip tags preserve line breaks' do
+    ''.strip_tags_preserve_line_breaks.must_equal ''
+    'test'.strip_tags_preserve_line_breaks.must_equal 'test'
 
-    assert_equal '', "\n".strip_tags_preserve_line_breaks
-    assert_equal 'X', "\nX".strip_tags_preserve_line_breaks
-    assert_equal 'X', "X\n".strip_tags_preserve_line_breaks
-    assert_equal 'X', "\n\nX\n\n".strip_tags_preserve_line_breaks
+    "\n".strip_tags_preserve_line_breaks.must_equal ''
+    "\nX".strip_tags_preserve_line_breaks.must_equal 'X'
+    "X\n".strip_tags_preserve_line_breaks.must_equal 'X'
+    "\n\nX\n\n".strip_tags_preserve_line_breaks.must_equal 'X'
 
-    assert_equal 'X<br/>Y', 'X<br/>Y'.strip_tags_preserve_line_breaks
-    assert_equal 'X<br/>Y', "X\nY".strip_tags_preserve_line_breaks
+    'X<br/>Y'.strip_tags_preserve_line_breaks.must_equal 'X<br/>Y'
+    "X\nY".strip_tags_preserve_line_breaks.must_equal 'X<br/>Y'
 
-    assert_equal 'X<br/><br/>Y', '<p>X</p>Y'.strip_tags_preserve_line_breaks
-    assert_equal 'X', '<p>X</p>'.strip_tags_preserve_line_breaks
+    '<p>X</p>Y'.strip_tags_preserve_line_breaks.must_equal 'X<br/><br/>Y'
+    '<p>X</p>'.strip_tags_preserve_line_breaks.must_equal 'X'
 
-    assert_equal 'XYZ', "X<a href='#'>Y</a>Z".strip_tags_preserve_line_breaks
-    assert_equal 'XYZ', 'X<h1>Y</h2>Z'.strip_tags_preserve_line_breaks
-    assert_equal 'X<Y', 'X<Y'.strip_tags_preserve_line_breaks
-    assert_equal 'X>Y', 'X>Y'.strip_tags_preserve_line_breaks
+    "X<a href='#'>Y</a>Z".strip_tags_preserve_line_breaks.must_equal 'XYZ'
+    'X<h1>Y</h2>Z'.strip_tags_preserve_line_breaks.must_equal 'XYZ'
+    'X<Y'.strip_tags_preserve_line_breaks.must_equal 'X<Y'
+    'X>Y'.strip_tags_preserve_line_breaks.must_equal 'X>Y'
 
-    assert_equal 'X>Y', 'X&gt;Y'.strip_tags_preserve_line_breaks
-    assert_equal 'X<Y', 'X&lt;Y'.strip_tags_preserve_line_breaks
-    assert_equal 'X&Y', 'X&amp;Y'.strip_tags_preserve_line_breaks
+    'X&gt;Y'.strip_tags_preserve_line_breaks.must_equal 'X>Y'
+    'X&lt;Y'.strip_tags_preserve_line_breaks.must_equal 'X<Y'
+    'X&amp;Y'.strip_tags_preserve_line_breaks.must_equal 'X&Y'
   end
 
-  test 'clean up weirdly encoded strings' do
+  it 'clean up weirdly encoded strings' do
     before = "* oprava chyby 33731\n* \xFAprava  podle Revize B anglick\xE9ho dokumentu\n"
     after = ['* oprava chyby 33731', '* �prava  podle Revize B anglick�ho dokumentu']
-    assert_equal after, before.fix_encoding_if_invalid!.split("\n")
+    before.fix_encoding_if_invalid!.split("\n").must_equal after
   end
 end

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -3,13 +3,13 @@ require 'test_helper'
 class ApplicationHelperTest < ActionView::TestCase
   include ApplicationHelper
 
-  test 'expander truncates strings on a word boundary' do
+  it 'expander truncates strings on a word boundary' do
     text = expander('It was the best of times.', 5, 10)
-    assert_equal 'It<span', text.gsub(/\s/, '')[0..6]
+    text.gsub(/\s/, '')[0..6].must_equal('It<span')
   end
 
-  test 'expander truncates strings without leaving a dangling comma' do
+  it 'expander truncates strings without leaving a dangling comma' do
     text = expander('It, or something like it, was the best of times.', 5, 10)
-    assert_equal 'It<span', text.gsub(/\s/, '')[0..6]
+    text.gsub(/\s/, '')[0..6].must_equal('It<span')
   end
 end

--- a/test/helpers/avatar_helper_test.rb
+++ b/test/helpers/avatar_helper_test.rb
@@ -4,53 +4,53 @@ class AvatarHelperTest < ActionView::TestCase
   include AvatarHelper
   fixtures :accounts, :people
 
-  test 'avatar_img_path should handle accounts' do
+  it 'avatar_img_path should handle accounts' do
     path = avatar_img_path(accounts(:admin))
-    assert path.ends_with? '.gif'
+    path.ends_with?('.gif').must_equal true
   end
 
-  test 'avatar_img_path should handle people' do
+  it 'avatar_img_path should handle people' do
     path = avatar_img_path(people(:jason))
-    assert path.ends_with? '.gif'
+    path.ends_with?('.gif').must_equal true
   end
 
-  test 'avatar_img_path should handle garbage for who' do
+  it 'avatar_img_path should handle garbage for who' do
     path = avatar_img_path('this was supported before for some reason')
-    assert path.ends_with? '.gif'
+    path.ends_with?('.gif').must_equal true
   end
 
-  test 'avatar_for should accept accounts' do
+  it 'avatar_for should accept accounts' do
     link = avatar_for(accounts(:admin))
-    assert link.starts_with? '<a'
+    link.starts_with?('<a').must_equal true
   end
 
-  test 'avatar_for should accept people' do
+  it 'avatar_for should accept people' do
     link = avatar_for(people(:jason))
-    assert link.starts_with? '<a'
+    link.starts_with?('<a').must_equal true
   end
 
-  test 'avatar_for should clamp sizes to 80' do
+  it 'avatar_for should clamp sizes to 80' do
     link = avatar_for(accounts(:admin), size: 1_000)
-    assert(/80/.match(link))
+    link.must_match(/80/)
   end
 
-  test 'avatar_for should allow overriding url' do
+  it 'avatar_for should allow overriding url' do
     link = avatar_for(accounts(:admin), url: 'http://cnn.com')
-    assert(/cnn\.com/.match(link))
+    link.must_match(/cnn\.com/)
   end
 
-  test 'avatar_for should allow inserting a title for an account' do
+  it 'avatar_for should allow inserting a title for an account' do
     link = avatar_for(accounts(:admin), title: true)
-    assert(/title/.match(link))
+    link.must_match(/title/)
   end
 
-  test 'avatar_for should allow inserting a title for an person' do
+  it 'avatar_for should allow inserting a title for an person' do
     link = avatar_for(people(:jason), title: true)
-    assert(/title/.match(link))
+    link.must_match(/title/)
   end
 
-  test 'avatar_for should allow inserting a title for garbage who' do
+  it 'avatar_for should allow inserting a title for garbage who' do
     link = avatar_for('this was supported before for some reason', url: 'http://cnn.com', title: true)
-    assert link.starts_with? '<a'
+    link.starts_with?('<a').must_equal true
   end
 end

--- a/test/mailers/deleted_account_notifier_test.rb
+++ b/test/mailers/deleted_account_notifier_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class DeletedAccountNotifierTest < ActiveSupport::TestCase
-  test 'email should be sent out when account is deleted' do
+  it 'email should be sent out when account is deleted' do
     assert_difference -> { ActionMailer::Base.deliveries.count } do
       create(:deleted_account, created_at: 4.days.ago)
     end

--- a/test/models/api_key_test.rb
+++ b/test/models/api_key_test.rb
@@ -2,45 +2,46 @@ require 'test_helper'
 
 class ApiKeyTest < ActiveSupport::TestCase
   fixtures :accounts
-  test 'defaults are populated on new' do
+
+  it 'defaults are populated on new' do
     api_key = create(:api_key)
-    assert_equal ApiKey::DEFAULT_DAILY_LIMIT, api_key.daily_limit
-    assert_equal ApiKey::STATUS_OK, api_key.status
+    api_key.daily_limit.must_equal ApiKey::DEFAULT_DAILY_LIMIT
+    api_key.status.must_equal ApiKey::STATUS_OK
   end
 
-  test 'may_i_have_another? when under limit' do
+  it 'may_i_have_another? when under limit' do
     api_key = create(:api_key)
-    assert_equal 0, api_key.daily_count
-    assert_equal true, api_key.may_i_have_another?
-    assert_equal 1, api_key.daily_count
+    api_key.daily_count.must_equal 0
+    api_key.may_i_have_another?.must_equal true
+    api_key.daily_count.must_equal 1
   end
 
-  test 'may_i_have_another? a new day dawns' do
+  it 'may_i_have_another? a new day dawns' do
     big_number = ApiKey::DEFAULT_DAILY_LIMIT * 2
     api_key = create(:api_key, day_began_at: Time.now - 1.year,
                                total_count: big_number,
                                daily_count: 27)
-    assert_equal true, api_key.may_i_have_another?
-    assert_equal big_number + 1, api_key.total_count
-    assert_equal 1, api_key.daily_count
+    api_key.may_i_have_another?.must_equal true
+    api_key.total_count.must_equal big_number + 1
+    api_key.daily_count.must_equal 1
   end
 
-  test 'may_i_have_another? when reached limit' do
+  it 'may_i_have_another? when reached limit' do
     api_key = create(:api_key, daily_count: ApiKey::DEFAULT_DAILY_LIMIT)
-    assert_equal false, api_key.may_i_have_another?
+    api_key.may_i_have_another?.must_equal false
   end
 
-  test 'may_i_have_another? false always for disabled_accounts' do
+  it 'may_i_have_another? false always for disabled_accounts' do
     api_key = create(:api_key, status: ApiKey::STATUS_DISABLED)
-    assert_equal false, api_key.may_i_have_another?
+    api_key.may_i_have_another?.must_equal false
   end
 
-  test 'may_i_have_another? a new day never dawns for disabled_accounts' do
+  it 'may_i_have_another? a new day never dawns for disabled_accounts' do
     api_key = create(:api_key, day_began_at: Time.now - 1.year, status: ApiKey::STATUS_DISABLED)
-    assert_equal false, api_key.may_i_have_another?
+    api_key.may_i_have_another?.must_equal false
   end
 
-  test 'reset_all! works as expected' do
+  it 'reset_all! works as expected' do
     day_began_at = Time.now.utc - 1.year
     api_key1 = create(:api_key, daily_count: 2,
                                 day_began_at: day_began_at)
@@ -56,16 +57,16 @@ class ApiKeyTest < ActiveSupport::TestCase
     api_key2.reload
     api_key3.reload
 
-    assert_equal 0, api_key1.daily_count
-    assert_not_equal day_began_at, api_key1.day_began_at
-    assert_equal ApiKey::STATUS_OK, api_key1.status
+    api_key1.daily_count.must_equal 0
+    api_key1.day_began_at.wont_equal day_began_at
+    api_key1.status.must_equal ApiKey::STATUS_OK
 
-    assert_equal 0, api_key2.daily_count
-    assert_not_equal day_began_at, api_key2.day_began_at
-    assert_equal ApiKey::STATUS_OK, api_key2.status
+    api_key2.daily_count.must_equal 0
+    api_key2.day_began_at.wont_equal day_began_at
+    api_key2.status.must_equal ApiKey::STATUS_OK
 
-    assert_equal 0, api_key3.daily_count
-    assert_not_equal day_began_at, api_key3.day_began_at
-    assert_equal ApiKey::STATUS_DISABLED, api_key3.status
+    api_key3.daily_count.must_equal 0
+    api_key3.day_began_at.wont_equal day_began_at
+    api_key3.status.must_equal ApiKey::STATUS_DISABLED
   end
 end

--- a/test/models/authenticator_test.rb
+++ b/test/models/authenticator_test.rb
@@ -3,38 +3,38 @@ require 'test_helper'
 class AuthenticatorTest < ActiveSupport::TestCase
   fixtures :accounts
 
-  test 'can authenticate via email' do
+  it 'can authenticate via email' do
     authenticator = Authenticator.new(login: 'admin@openhub.net', password: 'test')
-    assert_equal accounts(:admin).id, authenticator.account.id
-    assert_equal true, authenticator.correct_password?
+    authenticator.account.id.must_equal accounts(:admin).id
+    authenticator.correct_password?.must_equal true
   end
 
-  test 'can authenticate via login' do
+  it 'can authenticate via login' do
     authenticator = Authenticator.new(login: 'admin', password: 'test')
-    assert_equal accounts(:admin).id, authenticator.account.id
-    assert_equal true, authenticator.correct_password?
+    authenticator.account.id.must_equal accounts(:admin).id
+    authenticator.correct_password?.must_equal true
   end
 
-  test 'wrong password does not authenticate via email' do
+  it 'wrong password does not authenticate via email' do
     authenticator = Authenticator.new(login: 'admin@openhub.net', password: 'wrong')
-    assert_equal accounts(:admin).id, authenticator.account.id
-    assert_equal false, authenticator.correct_password?
+    authenticator.account.id.must_equal accounts(:admin).id
+    authenticator.correct_password?.must_equal false
   end
 
-  test 'wrong password does not authenticate via login' do
+  it 'wrong password does not authenticate via login' do
     authenticator = Authenticator.new(login: 'admin', password: 'wrong')
-    assert_equal accounts(:admin).id, authenticator.account.id
-    assert_equal false, authenticator.correct_password?
+    authenticator.account.id.must_equal accounts(:admin).id
+    authenticator.correct_password?.must_equal false
   end
 
-  test 'unknown user does not authenticate via email' do
+  it 'unknown user does not authenticate via email' do
     authenticator = Authenticator.new(login: 'I am a banana!', password: 'does not matter')
-    assert_equal nil, authenticator.account
-    assert_equal false, authenticator.correct_password?
+    authenticator.account.must_equal nil
+    authenticator.correct_password?.must_equal false
   end
 
-  test 'generate_salt when called ten times gives ten different salts back' do
+  it 'generate_salt when called ten times gives ten different salts back' do
     salts = (0...10).map { Authenticator.generate_salt }
-    assert_equal 10, salts.uniq.length
+    salts.uniq.length.must_equal 10
   end
 end

--- a/test/models/deleted_account_test.rb
+++ b/test/models/deleted_account_test.rb
@@ -3,28 +3,29 @@ require_relative '../test_helper'
 class DeletedAccountTest < ActiveSupport::TestCase
   setup :create_deleted_account
 
-  test 'it should validate the login and email address' do
+  it 'it should validate the login and email address' do
     deleted_account = build(:deleted_account, email: '', login: '')
-    assert_not deleted_account.valid?
-    assert_includes deleted_account.errors, :email
-    assert_includes deleted_account.errors, :login
+    deleted_account.valid?.must_equal false
+    deleted_account.valid?.must_equal false
+    deleted_account.errors.must_include :email
+    deleted_account.errors.must_include :login
   end
 
-  test 'it should find the deleted record of a user' do
+  it 'it should find the deleted record of a user' do
     deleted_account = DeletedAccount.find_deleted_account(@account.login)
-    assert_not deleted_account.nil?
+    deleted_account.wont_be_nil
   end
 
-  test 'it should elapse the time interval of 1 hour' do
+  it 'it should elapse the time interval of 1 hour' do
     account = create(:deleted_account, created_at: 4.days.ago)
-    assert account.feedback_time_elapsed?
+    account.feedback_time_elapsed?.must_equal true
   end
 
-  test 'it should not elapse the time interval of 1 hour for newly created records' do
-    assert !@account.feedback_time_elapsed?
+  it 'it should not elapse the time interval of 1 hour for newly created records' do
+    @account.feedback_time_elapsed?.must_equal false
   end
 
-  test 'it should deliver DeletedAccountNotifier after create' do
+  it 'it should deliver DeletedAccountNotifier after create' do
     account = build(:deleted_account, created_at: 4.days.ago)
     DeletedAccountNotifier.expects(:deletion).with(account).returns(Mail::Message.new)
     Mail::Message.any_instance.expects(:deliver)

--- a/test/models/domain_blacklist_test.rb
+++ b/test/models/domain_blacklist_test.rb
@@ -1,47 +1,46 @@
 require 'test_helper'
 
 class DomainBlacklistTest < ActiveSupport::TestCase
-  test 'responds to contains?' do
-    assert DomainBlacklist.respond_to?(:contains?)
+  it 'responds to contains?' do
+    DomainBlacklist.must_respond_to(:contains?)
   end
 
-  test 'contains? returns false if it does not contain a domain' do
-    assert_equal false, DomainBlacklist.contains?('non_existent_domain.com')
+  it 'contains? returns false if it does not contain a domain' do
+    DomainBlacklist.contains?('non_existent_domain.com').must_equal false
   end
 
-  test 'contains? returns true if it contains a domain' do
+  it 'contains? returns true if it contains a domain' do
     DomainBlacklist.create(domain: 'test_domain.com')
-    assert_equal true, DomainBlacklist.contains?('test_domain.com')
+    DomainBlacklist.contains?('test_domain.com').must_equal true
   end
 
-  test 'contains? returns false if it contains different domain' do
+  it 'contains? returns false if it contains different domain' do
     DomainBlacklist.create(domain: 'first_domain.com')
-    assert_equal false, DomainBlacklist.contains?('second_domain.com')
+    DomainBlacklist.contains?('second_domain.com').must_equal false
   end
 
-  test 'record creations is case insensitive' do
+  it 'record creations is case insensitive' do
     DomainBlacklist.create(domain: 'first_domain.com')
-    assert_raise ActiveRecord::RecordInvalid do
-      DomainBlacklist.create!(domain: 'First_Domain.com')
-    end
+    -> { DomainBlacklist.create!(domain: 'First_Domain.com') }
+      .must_raise(ActiveRecord::RecordInvalid)
   end
 
-  test 'contains? returns true for case insensitive match' do
+  it 'contains? returns true for case insensitive match' do
     DomainBlacklist.create(domain: 'case_insensitive.com')
-    assert_equal true, DomainBlacklist.contains?('Case_Insensitive.com')
+    DomainBlacklist.contains?('Case_Insensitive.com').must_equal true
   end
 
-  test 'email_banned? returns false for non-matching domain' do
-    assert_equal false, DomainBlacklist.email_banned?('bob@new_domain.com')
+  it 'email_banned? returns false for non-matching domain' do
+    DomainBlacklist.email_banned?('bob@new_domain.com').must_equal false
   end
 
-  test 'email_banned? returns true for same domain' do
+  it 'email_banned? returns true for same domain' do
     DomainBlacklist.create(domain: 'banned.com')
-    assert_equal true, DomainBlacklist.email_banned?('bad@banned.com')
+    DomainBlacklist.email_banned?('bad@banned.com').must_equal true
   end
 
-  test 'email_banned? returns true for case different domain' do
+  it 'email_banned? returns true for case different domain' do
     DomainBlacklist.create(domain: 'banned.com')
-    assert_equal true, DomainBlacklist.email_banned?('CAPS@BANNED.COM')
+    DomainBlacklist.email_banned?('CAPS@BANNED.COM').must_equal true
   end
 end

--- a/test/models/helpful_test.rb
+++ b/test/models/helpful_test.rb
@@ -3,25 +3,25 @@ require 'test_helper'
 class HelpfulTest < ActiveSupport::TestCase
   fixtures :accounts, :projects
 
-  def setup
-    @review = Review.create!(account_id: accounts(:admin).id, project: projects(:linux),
-                             comment: 'Dummy Comment', title: 'Dummy Title')
+  let(:review) do
+    Review.create!(account_id: accounts(:admin).id, project: projects(:linux),
+                   comment: 'Dummy Comment', title: 'Dummy Title')
   end
 
-  def test_cant_helpful_your_own_review
-    h = @review.helpfuls.create(account_id: @review.account_id)
-    assert !h.valid?
-    assert_equal ["can't moderate your own review"], h.errors[:account]
+  it 'test cant helpful your own review' do
+    h = review.helpfuls.create(account_id: review.account_id)
+    h.wont_be :valid?
+    h.errors[:account].must_equal ["can't moderate your own review"]
   end
 
-  def test_target
-    h = @review.helpfuls.create!(account_id: accounts(:user).id)
-    assert_equal @review, h.review
+  it 'test target' do
+    h = review.helpfuls.create!(account_id: accounts(:user).id)
+    h.review.must_equal review
   end
 
-  def test_after_save_updates_helpful_score
-    assert_difference('@review.reload.helpful_score', 1) do
-      @review.helpfuls.create!(account_id: accounts(:user).id, yes: true)
+  it 'test after save updates helpful score' do
+    assert_difference('review.reload.helpful_score', 1) do
+      review.helpfuls.create!(account_id: accounts(:user).id, yes: true)
     end
   end
 end

--- a/test/models/logo_test.rb
+++ b/test/models/logo_test.rb
@@ -1,91 +1,91 @@
 require_relative '../test_helper'
 
 class LogoTest < ActiveSupport::TestCase
-  test 'class_exists' do
-    assert Logo
-    assert Logo.new
+  it 'class_exists' do
+    Logo.must_be :present?
+    Logo.new.must_be :present?
   end
 
-  test 'invalid_file_type' do
+  it 'invalid_file_type' do
     logo = Logo.create(attachment_file_name: 'output.pdf', attachment_content_type: 'application/pdf')
-    assert_equal false, logo.valid?
-    assert_equal 2, logo.errors.size
-    assert_equal ['Open Hub accepts GIF, JPG, and PNG formats for logo images.'], logo.errors[:attachment_content_type]
+    logo.valid?.must_equal false
+    logo.errors.size.must_equal 2
+    logo.errors[:attachment_content_type].must_equal ['Open Hub accepts GIF, JPG, and PNG formats for logo images.']
   end
 
-  test 'support GIF images' do
+  it 'support GIF images' do
     assert_difference 'Logo.count' do
       Logo.create(attachment_file_name: 'imawesome.gif', attachment_content_type: 'image/gif')
     end
   end
 
-  test 'support JPG images' do
+  it 'support JPG images' do
     assert_difference 'Logo.count' do
       Logo.create(attachment_file_name: 'imawesome.jpg', attachment_content_type: 'image/jpeg')
     end
   end
 
-  test 'supports PNG images' do
+  it 'supports PNG images' do
     assert_difference 'Logo.count' do
       Logo.create(attachment_file_name: 'imawesome.png', attachment_content_type: 'image/png')
     end
   end
 
-  test 'invalid empty filename' do
+  it 'invalid empty filename' do
     logo = Logo.new
-    assert_equal false, logo.valid?
-    assert ['can\'t be blank'], logo.errors[:attachment_file_name]
+    logo.valid?.must_equal false
+    logo.errors[:attachment_file_name].must_equal ['can\'t be blank']
   end
 
-  test 'valid filename' do
+  it 'valid filename' do
     logo = Logo.new(attachment_file_name: 'test.jpg',
                     attachment_content_type: 'image/jpeg', attachment_file_size: '643')
-    assert logo.valid?
-    assert logo.errors.empty?
+    logo.must_be :valid?
+    logo.errors.must_be :empty?
   end
 
-  test 'invalid file size' do
+  it 'invalid file size' do
     logo = Logo.new(attachment_file_name: 'test.jpg',
                     attachment_content_type: 'image/jpeg', attachment_file_size: '6640643')
-    assert_equal false, logo.valid?
-    assert_equal ['File size is too big (must be less than 500 KB)'], logo.errors[:attachment_file_size]
+    logo.valid?.must_equal false
+    logo.errors[:attachment_file_size].must_equal ['File size is too big (must be less than 500 KB)']
   end
 
-  test 'Logo Upload with wrong URL' do
+  it 'Logo Upload with wrong URL' do
     logo = Logo.new(url: 'http://123456790notexist.com/ohloh.jpg', attachment_content_type: 'image/jpg')
     logo.save
-    assert_equal ['Invalid URL / Image not found'], logo.errors[:url]
+    logo.errors[:url].must_equal ['Invalid URL / Image not found']
   end
 
-  test 'Logo Upload with wrong file type' do
+  it 'Logo Upload with wrong file type' do
     logo = Logo.new(url: 'https://www.ohloh.net/robots.txt', attachment_content_type: 'text/plain')
     logo.save
-    assert_equal ['Open Hub accepts GIF, JPG, and PNG formats for logo images.'], logo.errors[:attachment]
+    logo.errors[:attachment].must_equal ['Open Hub accepts GIF, JPG, and PNG formats for logo images.']
   end
 
-  test 'Logo Upload with Huge file size of 5MB' do
+  it 'Logo Upload with Huge file size of 5MB' do
     logo = Logo.new(url: 'https://www.ohloh.net/images/clear.gif',
                     attachment_content_type: 'image/gif', attachment_file_size: '5242880')
     logo.save
-    assert_equal ['File size is too big (must be less than 500 KB)'], logo.errors[:attachment_file_size]
+    logo.errors[:attachment_file_size].must_equal ['File size is too big (must be less than 500 KB)']
   end
 
-  test 'Logo Upload with valid file' do
+  it 'Logo Upload with valid file' do
     logo = Logo.new(url: 'https://www.openhub.net/images/clear.gif',
                     attachment_content_type: 'image/gif')
     logo.save!
-    assert_equal 0, logo.errors.size
-    assert_equal 'clear', File.basename(logo.attachment.url, File.extname(logo.attachment.url))
-    assert_match 'tiny', logo.attachment.url(:tiny)
-    assert_match 'small', logo.attachment.url(:small)
-    assert_match 'med', logo.attachment.url(:med)
-    assert_equal 0, logo.errors.size
+    logo.errors.size.must_equal 0
+    File.basename(logo.attachment.url, File.extname(logo.attachment.url)).must_equal 'clear'
+    logo.attachment.url(:tiny).must_match 'tiny'
+    logo.attachment.url(:small).must_match 'small'
+    logo.attachment.url(:med).must_match 'med'
+    logo.errors.size.must_equal 0
   end
 
-  test 'Project without logo' do
-    assert_equal 'no_logo_16.png', Logo.default_file_name(:tiny)
-    assert_equal 'no_logo_32.png', Logo.default_file_name(:small)
-    assert_equal 'no_logo.png', Logo.default_file_name(:med)
-    assert_equal 'no_logo.png', Logo.default_file_name
+  it 'Project without logo' do
+    Logo.default_file_name(:tiny).must_equal 'no_logo_16.png'
+    Logo.default_file_name(:small).must_equal 'no_logo_32.png'
+    Logo.default_file_name(:med).must_equal 'no_logo.png'
+    Logo.default_file_name.must_equal 'no_logo.png'
   end
 end

--- a/test/models/markup_test.rb
+++ b/test/models/markup_test.rb
@@ -1,11 +1,11 @@
 require_relative '../test_helper'
 
 class MarkupTest < ActiveSupport::TestCase
-  test 'save cleanups up the raw html' do
+  it 'save cleanups up the raw html' do
     raw = "<script src='xss.js' />It was\nthe best of <b>cross</b> site scripts!"
     markup = Markup.create(raw: raw)
     markup.reload
-    assert_equal raw, markup.raw
-    assert_equal 'It was<br/>the best of cross site scripts!', markup.formatted
+    markup.raw.must_equal raw
+    markup.formatted.must_equal 'It was<br/>the best of cross site scripts!'
   end
 end

--- a/test/models/permission_test.rb
+++ b/test/models/permission_test.rb
@@ -2,13 +2,13 @@ require 'test_helper'
 
 class PermissionTest < ActiveSupport::TestCase
   fixtures :projects, :organizations
-  test 'default remainder for projects are for no restrictions' do
+  it 'default remainder for projects are for no restrictions' do
     permission = create(:permission, target: projects(:linux))
-    assert_equal false, permission.remainder
+    permission.remainder.must_equal false
   end
 
-  test 'default remainder for organizations are for no restrictions' do
+  it 'default remainder for organizations are for no restrictions' do
     permission = create(:permission, target: organizations(:linux))
-    assert_equal false, permission.remainder
+    permission.remainder.must_equal false
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,7 @@ SimpleCov.start 'rails'
 
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
+require 'minitest/rails'
 require 'dotenv'
 Dotenv.overload '.env.test'
 
@@ -12,6 +13,7 @@ ActiveRecord::Migration.maintain_test_schema!
 
 class ActiveSupport::TestCase
   include FactoryGirl::Syntax::Methods
+  extend MiniTest::Spec::DSL
 
   def login_as(account)
     @controller.session[:account_id] = account ? account.id : nil


### PR DESCRIPTION
### What's so nice about the Spec DSL?

``` ruby
assert_equal 1, @users.count
@users.count.must_equal 1

assert !response.body.match(api_key.name)
response.body.wont_match(api_key.name)

assert_instance_of User, @user
@user.must_be_instance_of User

assert Logo.new                      # creates non descriptive failure messages.
assert_equal true, Logo.new.present? # descriptive failure messages but redundant syntax.
Logo.new.must_be :present?           # cool eh?

# must_be opens up a lot of possibilities to create more readable assertions.
logo.must_be :valid?
@users.count.must_be :<=, 2

# Use let blocks instead of method definitions
def admin_account
  accounts(:admin)
end
## vs
let(:admin_account) { accounts(:admin) }

# Nesting tests
class Account::EncrypterTest < ActiveSupport::TestCase
  class Create < Account::EncrypterTest
    class After < Create
      ...
    class Before < Create
      ...

class Account::EncrypterTest < ActiveSupport::TestCase
  describe 'Create' do
    describe 'After' do
      ...
    describe 'Before' do
      ...
```
### MiniTest is included in ruby 1.9, why do we need the gem?

`minitest` is a ruby library and hence is meant to be agnostic about ruby frameworks.
`minitest-rails` provides rails specific functions like `assigns`, `must_redirect_to` etc. and a rails generator helper.
### I do not like the `it 'some test'` way, can I use the older syntax?

Yes. Since we are still inheriting from ActiveSupport::TestCase the older syntax will still be available. I renamed all `test` blocks to `it` because it made more sense to me.

``` ruby
it 'must do something'
## vs
test 'do something'
```
### This looks great, but will it make my tests run slower?
##### Without Spec DSL

$ time rake test
real    0m9.332s
user    0m7.557s
sys     0m0.739s
##### With Spec DSL

$ time rake test
real    0m9.591s
user    0m7.728s
sys     0m0.729s
