### PR TITLE
Limit faker generated text for string columns

### DIFF
--- a/test/factories/kudos.rb
+++ b/test/factories/kudos.rb
@@ -3,6 +3,6 @@ FactoryGirl.define do
     sender_id 1
     account_id 1
     project_id 1
-    message { Faker::Lorem.sentence }
+    message { Faker::Lorem.sentence(2) }
   end
 end


### PR DESCRIPTION
string column has a character limit of 80.

``` ruby
irb> 1_000.times.map { Faker::Lorem.sentence.length }.any? { |length| length > 79 }
=> true
irb> 1_00_000.times.map { Faker::Lorem.sentence(2).length }.any? { |length| length > 79 }
=> false
```

As we see multiple Lorem.sentence(2) invocations generate content within
79 characters. This makes it an ideal use case for populating string
columns.
