### PR TITLE
Having OhDelegator in a private github repository broke the ability to r...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ gem 'aws-sdk'
 gem 'squeel'
 gem 'pg_search'
 gem 'draper'
-gem 'oh_delegator', git: 'git@github.com:blackducksw/oh_delegator.git'
 
 group :development, :test, :vagrant do
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,3 @@
-GIT
-  remote: git@github.com:blackducksw/oh_delegator.git
-  revision: f12bd77c2f04e440ec97f9fd754c5740347113ba
-  specs:
-    oh_delegator (0.0.1)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -269,7 +263,6 @@ DEPENDENCIES
   letter_opener
   minitest-rails
   mocha
-  oh_delegator!
   paperclip
   pg
   pg_search

--- a/config/initializers/oh_delegator.rb
+++ b/config/initializers/oh_delegator.rb
@@ -1,0 +1,8 @@
+require "#{Rails.root}/lib/oh_delegator/parent_scope"
+require "#{Rails.root}/lib/oh_delegator/base"
+require "#{Rails.root}/lib/oh_delegator/delegable"
+require "#{Rails.root}/lib/oh_delegator/orm"
+
+ActiveSupport.on_load(:active_record) do
+  OhDelegator::ORM.setup(self)
+end

--- a/lib/oh_delegator/base.rb
+++ b/lib/oh_delegator/base.rb
@@ -1,0 +1,13 @@
+module OhDelegator
+  class Base < SimpleDelegator
+    extend ParentScope
+
+    def initialize(delegable)
+      super
+
+      define_singleton_method(delegable.class.name.underscore) do
+        @delegable ||= delegable
+      end
+    end
+  end
+end

--- a/lib/oh_delegator/delegable.rb
+++ b/lib/oh_delegator/delegable.rb
@@ -1,0 +1,19 @@
+module OhDelegator
+  module Delegable
+    def oh_delegators(*attributes)
+      attributes.each do |attribute|
+        # Read the delegator class alongwith the delegable.
+        klass = "#{ name }::#{ attribute.to_s.classify }".constantize
+
+        define_method attribute do
+          instance_variable_name = "@#{ attribute }"
+          instance_variable = instance_variable_get(instance_variable_name)
+
+          return instance_variable if instance_variable
+
+          instance_variable_set(instance_variable_name, klass.new(self))
+        end
+      end
+    end
+  end
+end

--- a/lib/oh_delegator/orm.rb
+++ b/lib/oh_delegator/orm.rb
@@ -1,0 +1,11 @@
+module OhDelegator
+  class ORM
+    class << self
+      def setup(base)
+        base.class_eval do
+          extend OhDelegator::Delegable
+        end
+      end
+    end
+  end
+end

--- a/lib/oh_delegator/parent_scope.rb
+++ b/lib/oh_delegator/parent_scope.rb
@@ -1,0 +1,17 @@
+module OhDelegator
+  module ParentScope
+    def parent_scope(&block)
+      delegable.class_exec(&block)
+    end
+
+    private
+
+    def delegable
+      @delegable ||= delegable_name.constantize
+    end
+
+    def delegable_name
+      @delegable_name ||= name.slice(/^[^:]+/)
+    end
+  end
+end


### PR DESCRIPTION
...un the puppet/vagrant runtime. If we need it to be in a gem, we'll need to actually publish gems to our gem-in-a-box. For now, just bring the code into the app.
