### PR TITLE
Fix ActsAsEditable errors when reloading classes in development

### DIFF
--- a/app/lib/acts_as_editable/lib/no_editor_account_error.rb
+++ b/app/lib/acts_as_editable/lib/no_editor_account_error.rb
@@ -1,2 +1,4 @@
-class ActsAsEditable::NoEditorAccountError < StandardError
+module ActsAsEditable
+  class NoEditorAccountError < StandardError
+  end
 end

--- a/app/lib/acts_as_editable/lib/undo_error.rb
+++ b/app/lib/acts_as_editable/lib/undo_error.rb
@@ -1,2 +1,4 @@
-class ActsAsEditable::UndoError < StandardError
+module ActsAsEditable
+  class UndoError < StandardError
+  end
 end


### PR DESCRIPTION
The original problem can be replicated with the following commands:

``` sh
$ git checkout f626dde^
$ rails c
/home/alex/projects/ohloh-ui/app/lib/acts_as_editable/lib/no_editor_account_error.rb:1:in `<top (required)>': uninitialized constant ActsAsEditable (NameError)
        from /home/alex/projects/ohloh-ui/app/lib/acts_as_editable/acts_as_editable.rb:1:in `require_relative'
```

This was because of the following line in application.rb:

``` ruby
Dir["#{Rails.root}/app/lib/acts_as_editable/*.rb"].each { |file| require file }
```

The error occurred because the `undo_error.rb` file got required before `acts_as_editable.rb`.

``` ruby
class ActsAsEditable::UndoError < StandardError
end
```

To resolve this we removed the explicit requiring of acts_as_editable. Rails 4 loads everything under `app/` by default. So we relied on Rails to do our work.

The removal of the explicit require created other issues when organization delegator was introduced in OTWO-3327.

``` sh
$ git checkout 86a6ae3^
$ rails c
/home/alex/.rvm/gems/ruby-2.1.5@ohloh-ui/gems/activerecord-4.1.7/lib/active_record/dynamic_matchers.rb:26:in `method_missing': undefined method `acts_as_editable' for #<Class:0x000000058df220> (NoMethodError)
        from /home/alex/projects/ohloh-ui/app/models/organization.rb:12:in `<class:Organization>'
```

After some debugging, we realized that **Draper** makes Rails load decorateable models and decorators before any other `app/*` files. So when it encounters `acts_as_editable` in `app/model/organization.rb`, we get an error. Hence we had to go back to a solution similar to the original.

``` sh
$ git show 86a6ae3
...
+++ b/config/initializers/require_app_lib.rb
+Dir["#{Rails.root}/app/lib/**/*.rb"].each { |file| require file }
```

This solved our original problem and the OTWO-3327 issue, but it brought up another error. In development where classes are reloaded, Rails fails to correctly reload ActsAsEditable.

``` sh
$ rails c
>> Project.first
>> reload!
>> Project.first
Reloading...
ArgumentError: A copy of ActsAsEditable::ClassMethods has been removed from the module tree but is still active!
from activesupport-4.1.7/lib/active_support/dependencies.rb:465:in `load_missing_constant'
```

We discovered that instead of explicitly including acts_as_editable's **InstanceMethods** if we rely on **ActiveSupport::Concern** to include instance methods, the module is reloaded correctly. Maybe Rails does some extra magic to reload concerns correctly if one relies on Rails' recommended pattern. However we do have to explicitly include **ActsAsEditable::InstanceMethods** to prevent loading `acts_as_editable` specific methods in non editable **ActiveRecord** models.

While trying out different configurations, we stumbled upon the current solution. I do not yet understand how this patch fixes the problem.
