### PR TITLE
Use Rails conventions to populate html title

### DIFF
--- a/app/views/api_keys/admin_index.html.haml
+++ b/app/views/api_keys/admin_index.html.haml
@@ -1,4 +1,4 @@
-- page_context[:title] = t :api_keys_title
+- content_for(:html_title) { t :api_keys_title }
 - opts = options_for_select(@sort_options.invert, selected: @sort)
 
 %h3.float_left

--- a/app/views/api_keys/edit.html.haml
+++ b/app/views/api_keys/edit.html.haml
@@ -1,3 +1,3 @@
-- page_context[:title] = t('api_keys.edit.page_title')
+- content_for(:html_title) { t('api_keys.edit.page_title') }
 - url = account_api_keys_path(@account, @api_key)
 = render partial: 'form', locals: { title: t('api_keys.edit.verb'), http_method: :put, url: url }

--- a/app/views/api_keys/index.html.haml
+++ b/app/views/api_keys/index.html.haml
@@ -1,4 +1,4 @@
-- page_context[:title] = t :api_keys_title
+- content_for(:html_title) { t :api_keys_title }
 
 %h2.float_left! #{link_to(t(:settings), settings_account_path(@account))} : #{@meta_title}
 .clear_both

--- a/app/views/api_keys/new.html.haml
+++ b/app/views/api_keys/new.html.haml
@@ -1,3 +1,3 @@
-- page_context[:title] = t('api_keys.new.page_title')
+- content_for(:html_title) { t('api_keys.new.page_title') }
 - url = account_api_keys_path(@account)
 = render partial: 'form', locals: { title: t('api_keys.new.verb'), http_method: :post, url: url }

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,7 +1,7 @@
 !!! 5
 %html
   %head
-    - page_title = page_context[:title] ? "#{page_context[:title]} - Open Hub" : 'Open Hub'
+    - page_title = content_for?(:html_title) ? "#{ yield(:html_title) } - Open Hub" : 'Open Hub'
     %title= page_title
     %meta{ name: 'viewport', content: 'width=device-width, initial-scale=1.0' }
     %meta{ name: 'description', content: page_context[:description] }

--- a/app/views/logos/new.html.haml
+++ b/app/views/logos/new.html.haml
@@ -1,5 +1,5 @@
 - if @organization
-  - @page_context[:title] = t('.meta_title')
+  - content_for(:html_title) { t('.meta_title') }
 -# else
   -# @meta_title_final = project_pages_title(t('.page_title'))
 .project_content_title

--- a/app/views/managers/edit.html.haml
+++ b/app/views/managers/edit.html.haml
@@ -1,4 +1,4 @@
-- page_context[:title] = project_pages_title t('.page_title')
+- content_for(:html_title) { project_pages_title t('.page_title') }
 
 %h2.float_left
   = link_to t(:settings), settings_parent_path(@parent)

--- a/app/views/managers/index.html.haml
+++ b/app/views/managers/index.html.haml
@@ -1,4 +1,4 @@
-- page_context[:title] = project_pages_title t('.page_title')
+- content_for(:html_title) { project_pages_title t('.page_title') }
 
 .project_content_title
   %h2.float_left

--- a/app/views/managers/new.html.haml
+++ b/app/views/managers/new.html.haml
@@ -1,4 +1,4 @@
-- page_context[:title] = project_pages_title t('.page_title')
+- content_for(:html_title) { project_pages_title t('.page_title') }
 
 %h2.float_left
   = link_to t(:settings), settings_parent_path(@parent)

--- a/app/views/permissions/show.html.haml
+++ b/app/views/permissions/show.html.haml
@@ -1,4 +1,4 @@
-- page_context[:title] = project_pages_title t('permissions.show.page_title')
+- content_for(:html_title) { project_pages_title t('permissions.show.page_title') }
 = javascript_include_tag 'permissions.js'
 
 .project_content_title

--- a/app/views/sessions/new.html.haml
+++ b/app/views/sessions/new.html.haml
@@ -1,4 +1,4 @@
-- page_context[:title] = t '.page_title'
+- content_for(:html_title) { t '.page_title' }
 
 .col-sm-7
   %h2= t('.page_header')


### PR DESCRIPTION
Instead of using a global `page_context` hash to set current page title, this patch aims to use the inbuilt `content_for` helper to do the same. Going forward we should try reducing our dependence on the `page_context` logic, so that it could be removed if possible.
