### PR TITLE
Fix issue with user activation

### DIFF
--- a/app/models/account/hooks.rb
+++ b/app/models/account/hooks.rb
@@ -60,7 +60,7 @@ class Account::Hooks
 
     invite.update!(invitee_id: account.id, activated_at: Time.now.utc)
 
-    Account::Access.new(account).activate!(account.invite_code) if invite.invitee_email.eql?(account.email)
+    Account::Access.new(account).activate!(account.activation_code) if invite.invitee_email.eql?(account.email)
   end
 
   def assign_name_to_login(account)


### PR DESCRIPTION
Account::Encrypter has a method `assign_activation_code_to_random_hash` that
sets `account.activation_code` to a random hash. Thus account.invite_code will
never be equal to account.activation_code.

Moreover this logic is not the same as in our older Ohloh source.  The older
code passed in account's `activation_code` to `activate!` method, thus ending
up comparing the same values. This was done to optionally avoid activation for
anonymous accounts where a nil value was passed to `activate!`. This patch
introduces a boolean argument to avoid the confusion.
