### PR TITLE
Remove redundant library requirements

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -15,10 +15,6 @@ module OhlohUi
     config.active_record.schema_format = :sql
     config.active_record.raise_in_transactional_callbacks = true
 
-    config.autoload_paths << "#{Rails.root}/app/exceptions"
     config.autoload_paths << "#{Rails.root}/lib"
   end
 end
-
-Dir["#{Rails.root}/app/lib/acts_as_editable/*.rb"].each { |file| require file }
-Dir["#{Rails.root}/app/lib/acts_as_protected/*.rb"].each { |file| require file }


### PR DESCRIPTION
With eager_load set to true, we would always have app/exceptions required.

``` ruby
> Rails.configuration.eager_load_paths.grep /exceptions/
=> [".../ohloh-ui/app/exceptions"]
```

Also `config/initializers/require_app_lib.rb` already requires the `acts_as_*` libraries.
