### PR TITLE
Fix `already initialized constant Ohloh::Cipher::KEY` error

### DIFF
--- a/config/initializers/require_app_lib.rb
+++ b/config/initializers/require_app_lib.rb
@@ -1,1 +1,4 @@
-Dir["#{Rails.root}/app/lib/**/*.rb"].each { |file| require file }
+app_library_path = Rails.root.join('app/lib')
+Dir[app_library_path.join('**/*.rb')].each { |file| require file }
+
+Rails.configuration.eager_load_paths.delete(app_library_path.to_s)


### PR DESCRIPTION
We need to require `app/lib` before any other `app/**` code. Hence we require it using an initializer. With `eager_load` set to true, Rails requires everything under the **app** directory after initializing. This causes the library modules to be required again, thus causing the already initialized module warning.

This patch modifies `Rails.configuration`, which might not be an ideal solution.
A better approach might be to move all library code from **app/lib** to **lib**. The **lib** folder will have to be required in the initializer but it will never be eager_loaded, thus avoiding the double require.
