### PR TITLE
Fix brakeman warning about XSS attack

### DIFF
--- a/app/views/api_keys/_api_key.html.haml
+++ b/app/views/api_keys/_api_key.html.haml
@@ -22,7 +22,7 @@
       %code{ title: secret }= secret
       - redirect_uri = oauth_application.redirect_uri
       - if redirect_uri
-        = link_to redirect_uri, redirect_uri, target: '_blank'
+        %a{ href: redirect_uri, target: '_blank' }= redirect_uri
         %i.icon-external-link.inline &nbsp;
       .clearfix
       - if api_key.url.present?


### PR DESCRIPTION
There is a possibility of an XSS attack when the application uses user
entered data in an `href`. For example if the user entered the data
`javascript:alert('XSS')` and we use it in an href on a page, the page
would run the `alert` function on load.

In our case, we have validations to prevent user from saving a non url
pattern for the redirect uri. So the brakeman warning is really not
relevant here. We just need this hack to stop brakeman from complaining.
