### PR TITLE
Add task for the CI system that will run the whole automated testing …

### DIFF
--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -1,0 +1,9 @@
+namespace :ci do
+  desc 'Run the complete build verification'
+  task :all_tasks do
+    exit(1) unless system('RAILS_ENV=test rake test')
+    exit(1) unless system('rubocop')
+    exit(1) unless system('brakeman -qz')
+    exit(1) unless system('haml-lint .')
+  end
+end


### PR DESCRIPTION
…architecture. If any of them fail, the whole thing stops and exits with a false value.

To run it locally:

```
rake ci:all_tasks
```

This will specifically start failing jobs with brakeman warnings.
