### PR TITLE
Make tags also encode its string. Handle two places where pluck() was…

### DIFF
--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -9,6 +9,7 @@ module TagsHelper
 
   def tag_links(tag_list, max_tags = tag_list.length)
     tag_list[0..(max_tags - 1)].collect do |tag|
+      tag.fix_encoding_if_invalid!
       link_to html_escape(tag), tags_path(names: tag), class: 'tag', itemprop: 'keywords'
     end.join(' ').html_safe
   end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -17,6 +17,8 @@ class Tag < ActiveRecord::Base
   validates :name, length: { within: 1..50 }, allow_nil: false,
                    format: { with: /\A[\w\+\(\)\_\-#]*\Z/, message: I18n.t('tags.allowed_characters') }
 
+  fix_string_column_encodings!
+
   class << self
     def autocomplete(project_id, query)
       by_popularity.for_projects

--- a/app/views/shared/search_dingus/_search_bar.html.haml
+++ b/app/views/shared/search_dingus/_search_bar.html.haml
@@ -2,7 +2,7 @@
   .search_tags
     %label= t('.filter_by_tags')
     .chosen#value_select
-      = select_tag :names, options_for_select(tags, params[:names]),
+      = select_tag :names, options_for_select(tags.map { |ary| ary.map(&:fix_encoding_if_invalid!) }, params[:names]),
         class: 'chzn-select value-select multiple-select',
         multiple: true, onchange: 'this.form.submit()'
 


### PR DESCRIPTION
… short-circuiting the Rails after_find mechanism.
