### PR TITLE
Change Time.now to Time.current

### DIFF
--- a/app/controllers/activation_resends_controller.rb
+++ b/app/controllers/activation_resends_controller.rb
@@ -15,7 +15,7 @@ class ActivationResendsController < ApplicationController
   end
 
   def prevent_email_delivery_for_recently_activated
-    return unless @account.activation_resent_at && Time.now.utc < @account.activation_resent_at.since(2.hours)
+    return unless @account.activation_resent_at && Time.current < @account.activation_resent_at.since(2.hours)
     redirect_to message_path, flash: { success: t('.recently_activated') }
   end
 

--- a/app/controllers/compares_controller.rb
+++ b/app/controllers/compares_controller.rb
@@ -38,8 +38,8 @@ class ComparesController < ApplicationController
   end
 
   def set_date_ranges
-    present_date = Time.now.utc
-    @end_date = Time.now.utc.strftime('%Y-%m-01')
+    present_date = Time.current
+    @end_date = Time.current.strftime('%Y-%m-01')
     @start_date = Time.utc(present_date.year - 3, present_date.month).strftime('%Y-%m-01')
   end
 

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -45,7 +45,7 @@ class PasswordResetsController < ApplicationController
   def check_token_expiration
     token_expires_at = @account.reset_password_tokens[params[:token]]
     return render_404 unless token_expires_at
-    return if token_expires_at > Time.now.utc
+    return if token_expires_at > Time.current
 
     redirect_to new_password_reset_path, flash: { error: t('password_resets.token_expired_error') }
   end

--- a/app/controllers/privacy_controller.rb
+++ b/app/controllers/privacy_controller.rb
@@ -21,7 +21,7 @@ class PrivacyController < ApplicationController
   end
 
   def update_email_opportunities_visited
-    @account.update_attribute(:email_opportunities_visited, Time.now.utc)
+    @account.update_attribute(:email_opportunities_visited, Time.current)
   end
 
   def set_oauth_applications

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -36,7 +36,7 @@ class SessionsController < ApplicationController
 
   def initialize_session_variables(account)
     session[:account_id] = account.id
-    session[:last_active] = Time.now.utc
+    session[:last_active] = Time.current
   end
 
   def remember_me_if_requested(account)

--- a/app/decorators/commits_by_project.rb
+++ b/app/decorators/commits_by_project.rb
@@ -35,13 +35,13 @@ class CommitsByProject < Cherry::Decorator
 
   def start_date
     return @start_date if @start_date
-    given_start_date = @context[:start_date] || (Time.now.utc - 7.years)
+    given_start_date = @context[:start_date] || (Time.current - 7.years)
     @start_date = given_start_date.strftime('%Y-%m-01').to_date
   end
 
   def end_date
     return @end_date if @end_date
-    given_end_date = @context[:end_date] || Time.now.utc
+    given_end_date = @context[:end_date] || Time.current
     @end_date = given_end_date.strftime('%Y-%m-01').to_date
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -115,7 +115,7 @@ module ApplicationHelper
 
   def highlight(actual_time, base_time = nil)
     return if actual_time.blank?
-    base_time ||= @highlight_from || Time.now
+    base_time ||= @highlight_from || Time.current
     return 'highlight' if actual_time >= base_time
   end
 

--- a/app/helpers/edits_helper.rb
+++ b/app/helpers/edits_helper.rb
@@ -1,6 +1,6 @@
 module EditsHelper
   def edit_humanize_datetime(datetime)
-    now = Time.now
+    now = Time.current
     return t('edits.edit_humanize_datetime', difference: time_ago_in_words(datetime)) if (now - datetime) < 24.hours
     return datetime.strftime('%b %d') if datetime.year == now.year
     datetime.strftime('%b %d, %Y')

--- a/app/helpers/kudos_helper.rb
+++ b/app/helpers/kudos_helper.rb
@@ -22,7 +22,7 @@ module KudosHelper
 
   def kudo_is_new?(account_id, created_at)
     return (session[:last_active] && (created_at > session[:last_active])) if account_id == current_user.id
-    created_at > Time.now.utc - 24.hours
+    created_at > Time.current - 24.hours
   end
 
   def kudo_delete_link_confirm(kudo)

--- a/app/lib/acts_as_editable/acts_as_editable.rb
+++ b/app/lib/acts_as_editable/acts_as_editable.rb
@@ -56,7 +56,7 @@ module ActsAsEditable
 
     def new_or_merged_property_edit(property)
       prop_edit = PropertyEdit.not_undone.for_property(property).for_target(self).for_editor(editor_account)
-      prop_edit = prop_edit.where(PropertyEdit.arel_table[:created_at].gt(Time.now - merge_within))
+      prop_edit = prop_edit.where(PropertyEdit.arel_table[:created_at].gt(Time.current - merge_within))
       prop_edit.first_or_initialize
     end
 

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -88,7 +88,7 @@ class Account < ActiveRecord::Base
 
   def resend_activation!
     AccountMailer.signup_notification(self).deliver_now
-    update!(activation_resent_at: Time.now.utc)
+    update!(activation_resent_at: Time.current)
   end
 
   # TODO: Replaces get_first_commit_date

--- a/app/models/account/access.rb
+++ b/app/models/account/access.rb
@@ -35,7 +35,7 @@ class Account::Access
 
   def activate!(activation_code)
     return unless !activated? && activation_code.eql?(@account.activation_code)
-    @account.update_attributes!(activated_at: Time.now.utc, activation_code: nil)
+    @account.update_attributes!(activated_at: Time.current, activation_code: nil)
   end
 
   def disable!

--- a/app/models/account/encrypter.rb
+++ b/app/models/account/encrypter.rb
@@ -21,7 +21,7 @@ class Account::Encrypter
   end
 
   def encrypt_salt(account)
-    account.salt = Account::Authenticator.encrypt(Time.now.to_s, account.login)
+    account.salt = Account::Authenticator.encrypt(Time.current.to_s, account.login)
   end
 
   def encrypt_password(account)

--- a/app/models/account/hooks.rb
+++ b/app/models/account/hooks.rb
@@ -55,7 +55,7 @@ class Account::Hooks
     invite = Invite.find_by(activation_code: account.invite_code)
     return unless invite
 
-    invite.update!(invitee_id: account.id, activated_at: Time.now.utc)
+    invite.update!(invitee_id: account.id, activated_at: Time.current)
 
     Account::Access.new(account).activate!(account.activation_code) if invite.invitee_email.eql?(account.email)
   end

--- a/app/models/activity_fact_by_month_query.rb
+++ b/app/models/activity_fact_by_month_query.rb
@@ -57,7 +57,7 @@ class ActivityFactByMonthQuery
   end
 
   def less_than
-    months[:month].lt(Time.now.utc)
+    months[:month].lt(Time.current)
   end
 
   def greater_than

--- a/app/models/analysis.rb
+++ b/app/models/analysis.rb
@@ -19,7 +19,7 @@ class Analysis < ActiveRecord::Base
   belongs_to :project
   belongs_to :main_language, class_name: 'Language', foreign_key: :main_language_id
 
-  scope :fresh, -> { where(Analysis.arel_table[:created_at].gt(Time.now - 2.days)) }
+  scope :fresh, -> { where(Analysis.arel_table[:created_at].gt(Time.current - 2.days)) }
   scope :hot, -> { where.not(hotness_score: nil).order(hotness_score: :desc) }
   scope :for_lang, ->(lang_id) { where(main_language_id: lang_id) }
 
@@ -88,15 +88,15 @@ class Analysis < ActiveRecord::Base
   end
 
   def old_analysis?
-    updated_on < Time.now - 30.days
+    updated_on < Time.current - 30.days
   end
 
   def new_first_commit?
-    first_commit_time > Time.now - 12.months
+    first_commit_time > Time.current - 12.months
   end
 
   def old_last_commit?
-    last_commit_time < Time.now - 24.months
+    last_commit_time < Time.current - 24.months
   end
 
   def too_small_team?

--- a/app/models/analysis/monthly_commits.rb
+++ b/app/models/analysis/monthly_commits.rb
@@ -25,10 +25,10 @@ class Analysis::MonthlyCommits < Analysis::QueryBase
   end
 
   def start_date
-    Time.now.utc - COMMIT_YEARS.years
+    Time.current - COMMIT_YEARS.years
   end
 
   def end_date
-    Time.now.utc
+    Time.current
   end
 end

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -31,7 +31,7 @@ class ApiKey < ActiveRecord::Base
   end
 
   def may_i_have_another?
-    now = Time.now.utc
+    now = Time.current
     daily_reset!
     update_attributes!(last_access_at: now,
                        day_began_at: day_began_at || now,
@@ -43,7 +43,7 @@ class ApiKey < ActiveRecord::Base
 
   class << self
     def reset_all!
-      ApiKey.update_all(daily_count: 0, day_began_at: Time.now.utc)
+      ApiKey.update_all(daily_count: 0, day_began_at: Time.current)
       ApiKey.where(status: STATUS_LIMIT_EXCEEDED).update_all(status: STATUS_OK)
     end
 
@@ -55,8 +55,8 @@ class ApiKey < ActiveRecord::Base
   private
 
   def daily_reset!
-    return unless day_began_at && day_began_at < (Time.now.utc - 1.day)
-    assign_attributes(day_began_at: Time.now.utc,
+    return unless day_began_at && day_began_at < (Time.current - 1.day)
+    assign_attributes(day_began_at: Time.current,
                       daily_count: 0,
                       status: (status == STATUS_LIMIT_EXCEEDED) ? STATUS_OK : status)
   end

--- a/app/models/cloud_tag.rb
+++ b/app/models/cloud_tag.rb
@@ -3,7 +3,7 @@ class CloudTag
 
   class << self
     def list
-      index = TAGS_LIST.length - Time.now.day
+      index = TAGS_LIST.length - Time.current.day
       TAGS_LIST[index].sort { |a, b| a[0] <=> b[0] }
     end
   end

--- a/app/models/contributor_fact.rb
+++ b/app/models/contributor_fact.rb
@@ -47,7 +47,7 @@ class ContributorFact < NameFact
   end
 
   def monthly_commits(years = 5)
-    options = { analysis: analysis, name_id: name_id, start_date: Time.now.utc - years.years, end_date: Time.now.utc }
+    options = { analysis: analysis, name_id: name_id, start_date: Time.current - years.years, end_date: Time.current }
     Analysis::CommitHistory.new(options).execute
   end
 

--- a/app/models/deleted_account.rb
+++ b/app/models/deleted_account.rb
@@ -16,7 +16,7 @@ class DeletedAccount < ActiveRecord::Base
   end
 
   def feedback_time_elapsed?
-    created_at < Time.now.utc - 1.hour
+    created_at < Time.current - 1.hour
   end
 
   private

--- a/app/models/edit.rb
+++ b/app/models/edit.rb
@@ -39,7 +39,7 @@ class Edit < ActiveRecord::Base
     fail ActsAsEditable::UndoError, I18n.t(undo ? 'edits.cant_undo' : 'edits.cant_redo') if (undone == undo)
     Edit.transaction do
       undo ? do_undo : do_redo
-      self.update_attributes!(undone: undo, undone_at: Time.now.utc, undone_by: editor.id)
+      self.update_attributes!(undone: undo, undone_at: Time.current, undone_by: editor.id)
     end
   end
 

--- a/app/models/language/chart.rb
+++ b/app/models/language/chart.rb
@@ -21,6 +21,6 @@ class Language::Chart
   private
 
   def set_start_date
-    @series['plotOptions']['series']['pointStart'] = Time.now.years_ago(10).to_f * 1000
+    @series['plotOptions']['series']['pointStart'] = Time.current.years_ago(10).to_f * 1000
   end
 end

--- a/app/models/language_fact.rb
+++ b/app/models/language_fact.rb
@@ -4,8 +4,8 @@ class LanguageFact < ActiveRecord::Base
 
   class << self
     def report(language, options = {})
-      start_month = options[:start_month] || Time.now.years_ago(10)
-      end_month = options[:end_month] || Time.now.months_ago(1)
+      start_month = options[:start_month] || Time.current.years_ago(10)
+      end_month = options[:end_month] || Time.current.months_ago(1)
       measure = options[:measure] || 'loc_changed'
 
       AllMonth.joins(join_clause(language.id))

--- a/app/models/manage.rb
+++ b/app/models/manage.rb
@@ -39,11 +39,11 @@ class Manage < ActiveRecord::Base
 
   def destroy_by!(destroyer)
     fail I18n.t(:not_authorized) unless can_destroy?(destroyer)
-    update_attributes!(deleted_by: destroyer.id, deleted_at: Time.now.utc)
+    update_attributes!(deleted_by: destroyer.id, deleted_at: Time.current)
   end
 
   def destroy
-    update_attributes(deleted_by: Account.hamster.id, deleted_at: Time.now.utc)
+    update_attributes(deleted_by: Account.hamster.id, deleted_at: Time.current)
   end
 
   private

--- a/app/models/password_reset.rb
+++ b/app/models/password_reset.rb
@@ -20,7 +20,7 @@ class PasswordReset
   def refresh_token_and_email_link
     token = SecureRandom.hex(16)
     account.reset_password_tokens ||= {}
-    account.reset_password_tokens[token] = Time.now.utc + PASSWORD_TOKEN_TTL
+    account.reset_password_tokens[token] = Time.current + PASSWORD_TOKEN_TTL
 
     # FIXME: Integrate this mailer action and view.
     # AccountNotifier.reset_password_link(account, token).deliver

--- a/app/models/position.rb
+++ b/app/models/position.rb
@@ -68,9 +68,9 @@ class Position < ActiveRecord::Base
   # nil: unknown (for some reason)
   # rubocop:disable Metrics/CyclomaticComplexity
   def effective_stop_date
-    stop_date || (ongoing && Time.now.utc) ||
-      (name_fact.try(:active?) && Time.now.utc) ||
-      name_fact.try(:last_checkin) || Time.now
+    stop_date || (ongoing && Time.current) ||
+      (name_fact.try(:active?) && Time.current) ||
+      name_fact.try(:last_checkin) || Time.current
   end
   # rubocop:enable Metrics/CyclomaticComplexity
 
@@ -86,7 +86,7 @@ class Position < ActiveRecord::Base
   end
 
   def active?
-    effective_ongoing? && !(stop_date.present? && stop_date < Time.now.utc)
+    effective_ongoing? && !(stop_date.present? && stop_date < Time.current)
   end
 
   def organization

--- a/app/models/position/validations.rb
+++ b/app/models/position/validations.rb
@@ -38,11 +38,11 @@ module Position::Validations
   end
 
   def start_date_must_be_in_past
-    errors.add(:start_date, I18n.t('position.start_date.in_future')) if start_date > Time.now.utc
+    errors.add(:start_date, I18n.t('position.start_date.in_future')) if start_date > Time.current
   end
 
   def stop_date_must_be_in_past
-    errors.add(:stop_date, I18n.t('position.stop_date.in_future')) if stop_date > Time.now.utc
+    errors.add(:stop_date, I18n.t('position.stop_date.in_future')) if stop_date > Time.current
   end
 
   def stop_date_must_be_later_than_start_date

--- a/app/models/rss_article.rb
+++ b/app/models/rss_article.rb
@@ -15,9 +15,9 @@ class RssArticle < ActiveRecord::Base
     end
 
     def set_time(item)
-      date = (item.published || item.pubDate || item.dc_date || Time.now).to_s
+      date = (item.published || item.pubDate || item.dc_date || Time.current).to_s
       time = Time.parse(date).utc
-      time = Time.now.utc if time > Time.now.utc
+      time = Time.current if time > Time.current
       time
     end
 

--- a/app/models/rss_feed.rb
+++ b/app/models/rss_feed.rb
@@ -11,7 +11,7 @@ class RssFeed < ActiveRecord::Base
 
   def fetch(current_user)
     handle_fetch(url, current_user)
-    self.last_fetch ||= Time.now.utc
+    self.last_fetch ||= Time.current
     schedule_next_fetch
     save(validate: false)
   end
@@ -28,7 +28,7 @@ class RssFeed < ActiveRecord::Base
     # If the fetch succeeds, another fetch will be scheduled 24 hours from now.
     # If the fetch fails, the wait until the next fetch will be doubled.
     if error
-      self.next_fetch = Time.now.utc + (Time.now.utc - self.last_fetch) * 2
+      self.next_fetch = Time.current + (Time.current - self.last_fetch) * 2
     else
       self.next_fetch = self.last_fetch + 1.day
     end
@@ -49,7 +49,7 @@ class RssFeed < ActiveRecord::Base
   def update_projects(current_user)
     projects.each do |p|
       p.editor_account = current_user
-      p.update_attribute(:updated_at, Time.now.utc)
+      p.update_attribute(:updated_at, Time.current)
     end
   end
 

--- a/app/models/stack_entry.rb
+++ b/app/models/stack_entry.rb
@@ -28,7 +28,7 @@ class StackEntry < ActiveRecord::Base
   end
 
   def destroy
-    update_attributes(deleted_at: Time.now.utc)
+    update_attributes(deleted_at: Time.current)
     update_counters
   end
 

--- a/app/views/languages/show.html.haml
+++ b/app/views/languages/show.html.haml
@@ -19,6 +19,6 @@
     .inset
       %h3= t('.active_contributors')
       %p= t('.active_contributors_desc', name: @language.nice_name,
-        start_date: Time.now.months_ago(2).at_beginning_of_month.strftime('%b %Y'),
-        end_date: Time.now.strftime('%b %Y'))
+        start_date: Time.current.months_ago(2).at_beginning_of_month.strftime('%b %Y'),
+        end_date: Time.current.strftime('%b %Y'))
       = render 'account', accounts: active_accounts, show_commits: true

--- a/app/views/layouts/partials/_footer.html.haml
+++ b/app/views/layouts/partials/_footer.html.haml
@@ -14,7 +14,7 @@
     %img{ alt: 'Creative Commons License', src: '//i.creativecommons.org/l/by/3.0/88x31.png' }
   Copyright
   %sup &copy;
-  = Time.now.year
+  = Time.current.year
   %span{ itemscope: '', itemtype: 'http://schema.org/CreativeWork' }
     %span{ itemprop: 'publisher' }
       %a{ href: 'http://www.blackducksoftware.com', target: '_blank' }= 'Black Duck Software, Inc.'
@@ -37,7 +37,7 @@
   %img{ src: image_path('footer/blackduck_mascot.png') }
   .clear &nbsp;
   %sup &copy;
-  = Time.now.year
+  = Time.current.year
 
   %span{ itemscope: '', itemtype: 'http://schema.org/CreativeWork' }
     %span{ itemprop: 'publisher' }

--- a/app/views/sitemap/index.xml.builder
+++ b/app/views/sitemap/index.xml.builder
@@ -1,4 +1,4 @@
-time = Time.now.strftime('%Y-%m-%d')
+time = Time.current.strftime('%Y-%m-%d')
 
 xml.instruct!
 xml.sitemapindex(xmlns: 'http://www.sitemaps.org/schemas/sitemap/0.9') do

--- a/app/views/sitemap/show.xml.builder
+++ b/app/views/sitemap/show.xml.builder
@@ -1,4 +1,4 @@
-time = Time.now.strftime('%Y-%m-%d')
+time = Time.current.strftime('%Y-%m-%d')
 
 xml.instruct!
 xml.urlset(xmlns: 'http://www.sitemaps.org/schemas/sitemap/0.9') do

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -14,7 +14,7 @@ describe 'AccountsController' do
   end
 
   def start_date_str(month = 0)
-    (Time.now - 6.years + month.months).beginning_of_month.strftime('%Y-%m-01 00:00:00')
+    (Time.current - 6.years + month.months).beginning_of_month.strftime('%Y-%m-01 00:00:00')
   end
 
   let(:user) do

--- a/test/controllers/activation_resends_controller_test.rb
+++ b/test/controllers/activation_resends_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 describe 'ActivationResendsController' do
   let(:account) { create(:account) }
   let(:unactivated) { create(:unactivated) }
-  let(:recently_activated) { create(:unactivated, activation_resent_at: Time.now) }
+  let(:recently_activated) { create(:unactivated, activation_resent_at: Time.current) }
 
   describe 'new' do
     it 'must respond with success' do

--- a/test/controllers/api_keys_controller_test.rb
+++ b/test/controllers/api_keys_controller_test.rb
@@ -78,9 +78,9 @@ class ApiKeysControllerTest < ActionController::TestCase
   end
 
   it 'index page should honor the sort order "most_recent_request"' do
-    api_key1 = create(:api_key, last_access_at: Time.now)
-    api_key2 = create(:api_key, last_access_at: Time.now - 1.day)
-    api_key3 = create(:api_key, last_access_at: Time.now + 1.day)
+    api_key1 = create(:api_key, last_access_at: Time.current)
+    api_key2 = create(:api_key, last_access_at: Time.current - 1.day)
+    api_key3 = create(:api_key, last_access_at: Time.current + 1.day)
     login_as @admin
     get :index, sort: 'most_recent_request'
     must_respond_with :ok
@@ -114,9 +114,9 @@ class ApiKeysControllerTest < ActionController::TestCase
   end
 
   it 'index page should honor the sort order "newest"' do
-    api_key1 = create(:api_key, created_at: Time.now)
-    api_key2 = create(:api_key, created_at: Time.now - 1.day)
-    api_key3 = create(:api_key, created_at: Time.now + 1.day)
+    api_key1 = create(:api_key, created_at: Time.current)
+    api_key2 = create(:api_key, created_at: Time.current - 1.day)
+    api_key3 = create(:api_key, created_at: Time.current + 1.day)
     login_as @admin
     get :index, sort: 'newest'
     must_respond_with :ok
@@ -126,9 +126,9 @@ class ApiKeysControllerTest < ActionController::TestCase
   end
 
   it 'index page should honor the sort order "oldest"' do
-    api_key1 = create(:api_key, created_at: Time.now)
-    api_key2 = create(:api_key, created_at: Time.now - 1.day)
-    api_key3 = create(:api_key, created_at: Time.now + 1.day)
+    api_key1 = create(:api_key, created_at: Time.current)
+    api_key2 = create(:api_key, created_at: Time.current - 1.day)
+    api_key3 = create(:api_key, created_at: Time.current + 1.day)
     login_as @admin
     get :index, sort: 'oldest'
     must_respond_with :ok
@@ -138,8 +138,8 @@ class ApiKeysControllerTest < ActionController::TestCase
   end
 
   it 'index page should honor the sort order "account_name"' do
-    api_key1 = create(:api_key, account_id: @user.id, created_at: Time.now - 1. day, name: 'Zzzzzzzz')
-    api_key2 = create(:api_key, account_id: @admin.id, created_at: Time.now, name: 'Aaaaaaaa')
+    api_key1 = create(:api_key, account_id: @user.id, created_at: Time.current - 1. day, name: 'Zzzzzzzz')
+    api_key2 = create(:api_key, account_id: @admin.id, created_at: Time.current, name: 'Aaaaaaaa')
     login_as @admin
     get :index, sort: 'account_name'
     must_respond_with :ok
@@ -149,9 +149,9 @@ class ApiKeysControllerTest < ActionController::TestCase
   end
 
   it 'index page should assume "newest" when the sort parameter is unsupported' do
-    api_key1 = create(:api_key, created_at: Time.now)
-    api_key2 = create(:api_key, created_at: Time.now - 1.day)
-    api_key3 = create(:api_key, created_at: Time.now + 1.day)
+    api_key1 = create(:api_key, created_at: Time.current)
+    api_key2 = create(:api_key, created_at: Time.current - 1.day)
+    api_key3 = create(:api_key, created_at: Time.current + 1.day)
     login_as @admin
     get :index, sort: 'I_am_a_banana!'
     must_respond_with :ok

--- a/test/controllers/contributions_controller_test.rb
+++ b/test/controllers/contributions_controller_test.rb
@@ -36,8 +36,8 @@ describe 'ContributionsController' do
 
   describe 'show' do
     it 'should return contribution' do
-      ContributorFact.any_instance.stubs(:first_checkin).returns(Time.now - 2.days)
-      ContributorFact.any_instance.stubs(:last_checkin).returns(Time.now)
+      ContributorFact.any_instance.stubs(:first_checkin).returns(Time.current - 2.days)
+      ContributorFact.any_instance.stubs(:last_checkin).returns(Time.current)
 
       get :show, project_id: @project.to_param, id: @contribution.id
 

--- a/test/controllers/managers_controller_test.rb
+++ b/test/controllers/managers_controller_test.rb
@@ -138,7 +138,7 @@ class ManagersControllerTest < ActionController::TestCase
   it 'test accept should fail for rejected manager' do
     login_as accounts(:joe)
     set_manager(accounts(:joe), @proj)
-    @proj.manages.each { |pa| pa.update_attributes!(deleted_by: 1, deleted_at: Time.now.utc) }
+    @proj.manages.each { |pa| pa.update_attributes!(deleted_by: 1, deleted_at: Time.current) }
     set_manager(accounts(:admin), @proj) # auto-approved
     manager_apply(accounts(:user), @proj)
     assert_no_difference 'Manage.where.not(approved_by: nil).where(deleted_at: nil).count' do

--- a/test/controllers/password_resets_controller_test.rb
+++ b/test/controllers/password_resets_controller_test.rb
@@ -4,7 +4,7 @@ describe 'PasswordResetsController' do
   let(:token) { SecureRandom.hex(16) }
   let(:original_password) { Faker::Internet.password  }
   let(:account) do
-    create(:account, reset_password_tokens: { token => Time.now.utc + 1.hour },
+    create(:account, reset_password_tokens: { token => Time.current + 1.hour },
                      password: original_password, password_confirmation: original_password)
   end
 
@@ -70,7 +70,7 @@ describe 'PasswordResetsController' do
     end
 
     it 'wont allow expired tokens' do
-      account.update! reset_password_tokens: { token => Time.now.utc }
+      account.update! reset_password_tokens: { token => Time.current }
 
       get :confirm, account_id: account.login, token: token
 

--- a/test/controllers/positions_controller_test.rb
+++ b/test/controllers/positions_controller_test.rb
@@ -43,7 +43,7 @@ describe 'PositionsController' do
       before { NameFact.create!(analysis: project.best_analysis, name: name_obj) }
 
       it 'must respond with a special flash message for invitees' do
-        account.update!(created_at: Time.now.utc)
+        account.update!(created_at: Time.current)
         login_as(account)
 
         assert_difference 'Position.count', 1 do

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -22,8 +22,8 @@ describe PostsController do
 
     it 'index should handle search for unlogged users' do
       login_as nil
-      create(:post, body: 'oldest', created_at: Time.now - 2.hours)
-      create(:post, body: 'newest', created_at: Time.now)
+      create(:post, body: 'oldest', created_at: Time.current - 2.hours)
+      create(:post, body: 'newest', created_at: Time.current)
       get :index, sort: 'newest'
       must_respond_with :ok
       response.body.must_match(/newest.*oldest/m)
@@ -43,8 +43,8 @@ describe PostsController do
     end
 
     it 'sorts index posts by newest' do
-      create(:post, body: 'oldest', created_at: Time.now - 2.hours)
-      create(:post, body: 'newest', created_at: Time.now)
+      create(:post, body: 'oldest', created_at: Time.current - 2.hours)
+      create(:post, body: 'newest', created_at: Time.current)
       get :index, sort: 'newest'
       must_respond_with :ok
       response.body.must_match(/newest.*oldest/m)
@@ -83,10 +83,10 @@ describe PostsController do
     end
 
     it 'filters index by query parameter and sorts by newest' do
-      create(:post, body: 'first Mozilla', created_at: Time.now - 3.hours)
-      create(:post, body: 'second Mozilla', created_at: Time.now - 2.hours)
-      create(:post, body: 'third Mozilla', created_at: Time.now)
-      create(:post, body: 'Dropbox', created_at: Time.now - 4.hours)
+      create(:post, body: 'first Mozilla', created_at: Time.current - 3.hours)
+      create(:post, body: 'second Mozilla', created_at: Time.current - 2.hours)
+      create(:post, body: 'third Mozilla', created_at: Time.current)
+      create(:post, body: 'Dropbox', created_at: Time.current - 4.hours)
       get :index, query: 'Mozilla', sort: 'newest'
       must_respond_with :ok
       response.body.must_match(/third\sMozilla.*second\sMozilla.*first\sMozilla/m)
@@ -141,8 +141,8 @@ describe PostsController do
     end
 
     it 'sorts by newest' do
-      create(:post, account: user, body: 'oldest', created_at: Time.now - 2.hours)
-      create(:post, account: user, body: 'newest', created_at: Time.now)
+      create(:post, account: user, body: 'oldest', created_at: Time.current - 2.hours)
+      create(:post, account: user, body: 'newest', created_at: Time.current)
       get :index, account_id: user, sort: 'newest'
       must_respond_with :ok
       response.body.must_match(/newest.*oldest/m)
@@ -162,10 +162,10 @@ describe PostsController do
     end
 
     it 'filters index by query parameter and sorts by newest' do
-      create(:post, account: user, body: 'first Mozilla', created_at: Time.now - 3.hours)
-      create(:post, account: user, body: 'second Mozilla', created_at: Time.now - 2.hours)
-      create(:post, account: user, body: 'third Mozilla', created_at: Time.now)
-      create(:post, account: user, body: 'Dropbox', created_at: Time.now - 4.hours)
+      create(:post, account: user, body: 'first Mozilla', created_at: Time.current - 3.hours)
+      create(:post, account: user, body: 'second Mozilla', created_at: Time.current - 2.hours)
+      create(:post, account: user, body: 'third Mozilla', created_at: Time.current)
+      create(:post, account: user, body: 'Dropbox', created_at: Time.current - 4.hours)
       get :index, account_id: user, query: 'Mozilla', sort: 'newest'
       must_respond_with :ok
       response.body.must_match(/third\sMozilla.*second\sMozilla.*first\sMozilla/m)

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -24,7 +24,7 @@ describe 'ProjectsController' do
   end
 
   it 'index should handle query param sorting by new' do
-    create(:project, name: 'Foo_new', description: 'second', created_at: Time.now - 3.hours)
+    create(:project, name: 'Foo_new', description: 'second', created_at: Time.current - 3.hours)
     create(:project, name: 'FooBar_new', description: 'first')
     login_as nil
     get :index, query: 'foo', sort: 'new'
@@ -159,7 +159,7 @@ describe 'ProjectsController' do
   end
 
   it 'index should handle account sorting by "new"' do
-    project1 = create(:project, name: 'Foo_accounts_new', description: 'second', created_at: Time.now - 3.hours)
+    project1 = create(:project, name: 'Foo_accounts_new', description: 'second', created_at: Time.current - 3.hours)
     project2 = create(:project, name: 'FooBar_accounts_new', description: 'first')
     login_as nil
     manager = create(:account)

--- a/test/controllers/sitemap_controller_test.rb
+++ b/test/controllers/sitemap_controller_test.rb
@@ -19,9 +19,9 @@ describe 'SitemapController' do
       xml['xmlns'].must_equal 'http://www.sitemaps.org/schemas/sitemap/0.9'
       xml['sitemap'].size.must_equal 2
       xml['sitemap'].first['loc'].must_equal 'http://test.host/sitemaps/projects/1.xml'
-      xml['sitemap'].first['lastmod'].must_equal Time.now.strftime('%Y-%m-%d')
+      xml['sitemap'].first['lastmod'].must_equal Time.current.strftime('%Y-%m-%d')
       xml['sitemap'].last['loc'].must_equal 'http://test.host/sitemaps/accounts/1.xml'
-      xml['sitemap'].last['lastmod'].must_equal Time.now.strftime('%Y-%m-%d')
+      xml['sitemap'].last['lastmod'].must_equal Time.current.strftime('%Y-%m-%d')
     end
   end
 
@@ -41,7 +41,7 @@ describe 'SitemapController' do
       urls.must_include "http://test.host/p/#{@projects.third.url_name}"
       urls.must_include "http://test.host/p/#{@projects.fourth.url_name}"
       urls.must_include "http://test.host/p/#{@projects.last.url_name}"
-      xml['url'].map { |url| url['lastmod'] }.must_equal [Time.now.strftime('%Y-%m-%d')] * active_count
+      xml['url'].map { |url| url['lastmod'] }.must_equal [Time.current.strftime('%Y-%m-%d')] * active_count
       xml['url'].map { |url| url['priority'] }.must_equal ['0.8'] * active_count
       xml['url'].map { |url| url['changefreq'] }.must_equal ['daily'] * active_count
     end
@@ -61,7 +61,7 @@ describe 'SitemapController' do
       urls.must_include "http://test.host/accounts/#{@accounts.third.login}"
       urls.must_include "http://test.host/accounts/#{@accounts.fourth.login}"
       urls.must_include "http://test.host/accounts/#{@accounts.last.login}"
-      xml['url'].map { |url| url['lastmod'] }.must_equal [Time.now.strftime('%Y-%m-%d')] * active_count
+      xml['url'].map { |url| url['lastmod'] }.must_equal [Time.current.strftime('%Y-%m-%d')] * active_count
       xml['url'].map { |url| url['priority'] }.must_equal ['0.6'] * active_count
       xml['url'].map { |url| url['changefreq'] }.must_equal ['daily'] * active_count
     end

--- a/test/decorators/baseball_card_test.rb
+++ b/test/decorators/baseball_card_test.rb
@@ -7,7 +7,7 @@ class BaseballCardTest < ActiveSupport::TestCase
     it 'should return all rows with their values' do
       org = create(:organization)
       best_vita = create(:best_vita)
-      best_vita.account.update_attributes(best_vita_id: best_vita.id, created_at: Time.now - 4.days)
+      best_vita.account.update_attributes(best_vita_id: best_vita.id, created_at: Time.current - 4.days)
       Account::OrganizationCore.any_instance.stubs(:positions).returns([create_position])
       Account::OrganizationCore.any_instance.stubs(:orgs_for_my_positions).returns([org])
       Account::OrganizationCore.any_instance.stubs(:affiliations_for_my_positions).returns([org])

--- a/test/decorators/commits_by_project_test.rb
+++ b/test/decorators/commits_by_project_test.rb
@@ -2,11 +2,11 @@ require 'test_helper'
 
 class CommitsByProjectTest < ActiveSupport::TestCase
   let(:start_date_val) do
-    (Time.now - 6.years).beginning_of_month
+    (Time.current - 6.years).beginning_of_month
   end
 
   def start_date_str(month = 0)
-    (Time.now - 6.years + month.months).beginning_of_month.strftime('%Y-%m-01 00:00:00')
+    (Time.current - 6.years + month.months).beginning_of_month.strftime('%Y-%m-01 00:00:00')
   end
 
   let(:user) do

--- a/test/factories/accounts.rb
+++ b/test/factories/accounts.rb
@@ -16,7 +16,7 @@ FactoryGirl.define do
     twitter_account 'openhub'
     name { Faker::Name.name + rand(999_999).to_s }
     about_raw { Faker::Lorem.characters(10) }
-    activated_at { Time.now.utc }
+    activated_at { Time.current }
     activation_code nil
     country_code 'us'
     email_master true

--- a/test/factories/analyses.rb
+++ b/test/factories/analyses.rb
@@ -5,10 +5,10 @@ FactoryGirl.define do
     markup_total 100
     logic_total 101
     build_total 102
-    first_commit_time { Time.now - 1.year }
+    first_commit_time { Time.current - 1.year }
     min_month { Date.today - 1.month }
     max_month { Date.today - 1.day }
-    last_commit_time { Time.now - 1.day }
+    last_commit_time { Time.current - 1.day }
     after(:create) do |instance|
       instance.update_attributes(thirty_day_summary: create(:thirty_day_summary, analysis: instance))
       instance.update_attributes(twelve_month_summary: create(:twelve_month_summary, analysis: instance))

--- a/test/factories/commit_flags.rb
+++ b/test/factories/commit_flags.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :commit_flag do
     association :commit
     association :sloc_set
-    time { Time.now }
+    time { Time.current }
     type 'CommitFlag::NewLanguage'
     data { { language_id: create(:language).id } }
   end

--- a/test/factories/commits.rb
+++ b/test/factories/commits.rb
@@ -2,6 +2,6 @@ FactoryGirl.define do
   factory :commit do
     association :code_set
     association :name
-    time { Time.now.at_beginning_of_month }
+    time { Time.current.at_beginning_of_month }
   end
 end

--- a/test/factories/language_facts.rb
+++ b/test/factories/language_facts.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :language_fact do
     association :language
-    month { Time.now }
+    month { Time.current }
   end
 end

--- a/test/factories/name_facts.rb
+++ b/test/factories/name_facts.rb
@@ -1,5 +1,5 @@
 def start_date_str(month = 0)
-  (Time.now - 6.years + month.months).beginning_of_month.strftime('%Y-%m-01 00:00:00')
+  (Time.current - 6.years + month.months).beginning_of_month.strftime('%Y-%m-01 00:00:00')
 end
 
 def start_date
@@ -19,8 +19,8 @@ FactoryGirl.define do
     association :name
     association :primary_language, factory: :language
     type 'VitaFact'
-    first_checkin Time.now - 3.days
-    last_checkin Time.now - 1.day
+    first_checkin Time.current - 3.days
+    last_checkin Time.current - 1.day
     commits_by_project [{ 'month' => start_date_str, 'commits' => '25', 'position_id' => '1' },
                         { 'month' => start_date_str(1), 'commits' => '40', 'position_id' => '1' },
                         { 'month' => start_date_str(2), 'commits' => '28', 'position_id' => '1' },

--- a/test/factories/post.rb
+++ b/test/factories/post.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
     association :topic
     body { Faker::Lorem.sentence }
     sequence :created_at do |n|
-      Time.now + n
+      Time.current + n
     end
   end
 end

--- a/test/factories/topics.rb
+++ b/test/factories/topics.rb
@@ -10,7 +10,7 @@ FactoryGirl.define do
       "#{n}"
     end
     sequence :replied_at do |n|
-      Time.now + n
+      Time.current + n
     end
 
     factory :topic_with_posts, parent: :topic do

--- a/test/helpers/edits_helper_test.rb
+++ b/test/helpers/edits_helper_test.rb
@@ -5,19 +5,19 @@ class EditsHelperTest < ActionView::TestCase
 
   describe 'edit_humanize_datetime' do
     it 'reduce to time_ago_in_words when it was today' do
-      edit_humanize_datetime(Time.now - 1.second).must_match 'ago'
-      edit_humanize_datetime(Time.now - 1.minute).must_match 'ago'
-      edit_humanize_datetime(Time.now - 1.hour).must_match 'ago'
+      edit_humanize_datetime(Time.current - 1.second).must_match 'ago'
+      edit_humanize_datetime(Time.current - 1.minute).must_match 'ago'
+      edit_humanize_datetime(Time.current - 1.hour).must_match 'ago'
     end
 
     it 'drop the year if it was this year' do
-      other_time = Time.now - 17.days
-      dont_fail_around_new_years_date = Time.new(Time.now.year, other_time.month, other_time.day)
-      edit_humanize_datetime(dont_fail_around_new_years_date).wont_match Time.now.year
+      other_time = Time.current - 17.days
+      dont_fail_around_new_years_date = Time.new(Time.current.year, other_time.month, other_time.day)
+      edit_humanize_datetime(dont_fail_around_new_years_date).wont_match Time.current.year
     end
 
     it 'includes the year if it was before this year' do
-      other_time = Time.now - 1700.days
+      other_time = Time.current - 1700.days
       edit_humanize_datetime(other_time).must_match other_time.year.to_s
     end
   end

--- a/test/lib/acts_as_editable/acts_as_editable_test.rb
+++ b/test/lib/acts_as_editable/acts_as_editable_test.rb
@@ -4,7 +4,7 @@ class ActsAsEditable::ActsAsEditableTest < ActiveSupport::TestCase
   fixtures :accounts
 
   it 'edits get created on new project' do
-    project = create(:project, name: 'Foo', description: 'Best of projects!', created_at: Time.now)
+    project = create(:project, name: 'Foo', description: 'Best of projects!', created_at: Time.current)
     CreateEdit.where(target: project).count.must_equal 1
     PropertyEdit.where(target: project, key: 'name', value: 'Foo').count.must_equal 1
     PropertyEdit.where(target: project, key: 'description', value: 'Best of projects!').count.must_equal 1
@@ -19,7 +19,7 @@ class ActsAsEditable::ActsAsEditableTest < ActiveSupport::TestCase
   end
 
   it 'edits do not get their property edits merged if they are not recent to one another' do
-    long_ago = Time.now - 5.days
+    long_ago = Time.current - 5.days
     Time.stubs(:now).returns long_ago
     project = create(:project, name: 'Foobar')
     Time.unstub(:now)

--- a/test/models/account/position_core_test.rb
+++ b/test/models/account/position_core_test.rb
@@ -11,7 +11,7 @@ class PositionCoreTest < ActiveSupport::TestCase
     project_foo = create(:project, name: :foo, url_name: :foo)
     project_bar = create(:project, name: :bar, url_name: :bar)
 
-    common_attributes = { account: accounts(:admin), start_date: Time.now, stop_date: Time.now }
+    common_attributes = { account: accounts(:admin), start_date: Time.current, stop_date: Time.current }
     create_position(common_attributes.merge(project: project_foo))
     create_position(common_attributes.merge(project: project_bar, title: :bar_title))
     accounts(:admin).position_core.with_projects.count.must_equal 2

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -146,7 +146,7 @@ class AccountTest < ActiveSupport::TestCase
   end
 
   it 'should return recently active accounts' do
-    name_facts(:vitafact).update_attributes(last_checkin: Time.now)
+    name_facts(:vitafact).update_attributes(last_checkin: Time.current)
     recently_active = Account.recently_active
     recently_active.wont_be_nil
     recently_active.count.must_equal 1

--- a/test/models/analysis_test.rb
+++ b/test/models/analysis_test.rb
@@ -2,8 +2,8 @@ require 'test_helper'
 
 class AnalysisTest < ActiveSupport::TestCase
   let(:analysis) do
-    create(:analysis, updated_on: Time.now - 5.years, first_commit_time: Time.now - 10.years,
-                      last_commit_time: Time.now - 10.years, headcount: 10, min_month: Time.now - 10.years,
+    create(:analysis, updated_on: Time.current - 5.years, first_commit_time: Time.current - 10.years,
+                      last_commit_time: Time.current - 10.years, headcount: 10, min_month: Time.current - 10.years,
                       logic_total: 100, markup_total: 100, build_total: 100)
   end
 
@@ -17,24 +17,25 @@ class AnalysisTest < ActiveSupport::TestCase
     end
 
     it 'returns new for brand new new projects' do
-      analysis.update_attributes(updated_on: Time.now - 5.minute, first_commit_time: Time.now - 10.minute,
-                                 last_commit_time: Time.now - 10.minute, min_month: Time.now - 10.minute)
+      analysis.update_attributes(updated_on: Time.current - 5.minute, first_commit_time: Time.current - 10.minute,
+                                 last_commit_time: Time.current - 10.minute, min_month: Time.current - 10.minute)
       analysis.activity_level.must_equal :new
     end
 
     it 'returns inactive for abandonned projects' do
-      analysis.update_attributes(updated_on: Time.now - 5.minute)
+      analysis.update_attributes(updated_on: Time.current - 5.minute)
       analysis.activity_level.must_equal :inactive
     end
 
     it 'returns very low for projects with almost no committers' do
-      analysis.update_attributes(updated_on: Time.now - 5.minute, last_commit_time: Time.now - 10.minute, headcount: 1)
+      analysis.update_attributes(updated_on: Time.current - 5.minute,
+                                 last_commit_time: Time.current - 10.minute, headcount: 1)
       analysis.activity_level.must_equal :very_low
     end
 
     it 'returns correct values for various activity scores' do
-      analysis.update_attributes(updated_on: Time.now - 5.minute,
-                                 last_commit_time: Time.now - 10.minute,
+      analysis.update_attributes(updated_on: Time.current - 5.minute,
+                                 last_commit_time: Time.current - 10.minute,
                                  activity_score: 1)
       analysis.activity_level.must_equal :very_low
 
@@ -84,8 +85,8 @@ class AnalysisTest < ActiveSupport::TestCase
 
   describe 'fresh_and_hot' do
     it 'should return recent analysis' do
-      analysis.update_attributes(updated_on: Time.now - 5.minute,
-                                 last_commit_time: Time.now - 10.minute,
+      analysis.update_attributes(updated_on: Time.current - 5.minute,
+                                 last_commit_time: Time.current - 10.minute,
                                  hotness_score: 100)
       Analysis.fresh_and_hot(analysis.main_language_id).must_equal [analysis]
     end

--- a/test/models/api_key_test.rb
+++ b/test/models/api_key_test.rb
@@ -16,7 +16,7 @@ class ApiKeyTest < ActiveSupport::TestCase
 
   it 'may_i_have_another? a new day dawns' do
     big_number = ApiKey::DEFAULT_DAILY_LIMIT * 2
-    api_key = create(:api_key, day_began_at: Time.now - 1.year,
+    api_key = create(:api_key, day_began_at: Time.current - 1.year,
                                total_count: big_number,
                                daily_count: 27)
     api_key.may_i_have_another?.must_equal true
@@ -35,12 +35,12 @@ class ApiKeyTest < ActiveSupport::TestCase
   end
 
   it 'may_i_have_another? a new day never dawns for disabled_accounts' do
-    api_key = create(:api_key, day_began_at: Time.now - 1.year, status: ApiKey::STATUS_DISABLED)
+    api_key = create(:api_key, day_began_at: Time.current - 1.year, status: ApiKey::STATUS_DISABLED)
     api_key.may_i_have_another?.must_equal false
   end
 
   it 'reset_all! works as expected' do
-    day_began_at = Time.now.utc - 1.year
+    day_began_at = Time.current - 1.year
     api_key1 = create(:api_key, daily_count: 2,
                                 day_began_at: day_began_at)
     api_key2 = create(:api_key, daily_count: 3,

--- a/test/models/concerns/report_test.rb
+++ b/test/models/concerns/report_test.rb
@@ -5,7 +5,7 @@ class ReportTest < ActiveSupport::TestCase
     set_date_ranges
     project_analysis = create(:analysis_with_multiple_activity_facts)
     (1..3).to_a.each do |value|
-      create(:all_month, month: Time.utc(Time.now.utc.year, value, 1))
+      create(:all_month, month: Time.utc(Time.current.year, value, 1))
     end
     plot_points = project_analysis.contributor_history(@start_date, @end_date)
     plot_points = plot_points.map { |values| values['contributors'].to_i }
@@ -16,7 +16,7 @@ class ReportTest < ActiveSupport::TestCase
     project_analysis = create(:analysis_with_multiple_activity_facts)
     set_date_ranges
     (1..3).to_a.each do |value|
-      create(:all_month, month: Time.utc(Time.now.utc.year, value, 1))
+      create(:all_month, month: Time.utc(Time.current.year, value, 1))
     end
     plot_points = project_analysis.commit_history(@start_date, @end_date)
     plot_points = plot_points.map { |values| values['commits'].to_i }
@@ -27,7 +27,7 @@ class ReportTest < ActiveSupport::TestCase
     project_analysis = create(:analysis_with_multiple_activity_facts)
     set_date_ranges
     (1..3).to_a.each do |value|
-      create(:all_month, month: Time.utc(Time.now.utc.year, value, 1))
+      create(:all_month, month: Time.utc(Time.current.year, value, 1))
     end
     plot_points = project_analysis.code_total_history(@start_date, @end_date)
     plot_points = plot_points.map { |values| values['code_total'].to_i }
@@ -37,8 +37,8 @@ class ReportTest < ActiveSupport::TestCase
   private
 
   def set_date_ranges
-    @date = Time.utc(Time.now.utc.year, 1, 1)
-    @end_date = Time.now.utc.strftime('%Y-%m-01')
+    @date = Time.utc(Time.current.year, 1, 1)
+    @end_date = Time.current.strftime('%Y-%m-01')
     @start_date = Time.utc(@date.year, 1, 1).strftime('%Y-%m-01')
   end
 end

--- a/test/models/contribution_test.rb
+++ b/test/models/contribution_test.rb
@@ -141,16 +141,16 @@ class ContributionTest < ActiveSupport::TestCase
   def create_people_for_sort_by
     Person.update_all(kudo_position: 10)
     ContributorFact.update_all(commits: nil, twelve_month_commits: nil,
-                               last_checkin: nil, first_checkin: (Time.now - 5.years))
+                               last_checkin: nil, first_checkin: (Time.current - 5.years))
     @person1 = create(:person, effective_name: 'AB test', kudo_position: 3)
     @person1.contributor_fact.update_columns(commits: 10, twelve_month_commits: 3,
-                                             last_checkin: Time.now, first_checkin: Time.now)
+                                             last_checkin: Time.current, first_checkin: Time.current)
     @person2 = create(:person, effective_name: 'AA test', kudo_position: 2)
     @person2.contributor_fact.update_columns(commits: 9, twelve_month_commits: 4,
-                                             last_checkin: Time.now + 1, first_checkin: Time.now + 1)
+                                             last_checkin: Time.current + 1, first_checkin: Time.current + 1)
     @person3 = create(:person, effective_name: 'AC test', kudo_position: 1)
     @person3.contributor_fact.update_columns(commits: 8, twelve_month_commits: 5,
-                                             last_checkin: Time.now + 2, first_checkin: Time.now + 2)
+                                             last_checkin: Time.current + 2, first_checkin: Time.current + 2)
   end
 
   def find_contribution(join, sort_by)

--- a/test/models/edit_test.rb
+++ b/test/models/edit_test.rb
@@ -7,7 +7,7 @@ class EditTest < ActiveSupport::TestCase
     project = create(:project, description: 'Linux')
     Edit.for_target(project).delete_all
     @edit = create(:create_edit, target: project)
-    @previous_edit = create(:create_edit, value: '456', created_at: Time.now - 5.days, target: project)
+    @previous_edit = create(:create_edit, value: '456', created_at: Time.current - 5.days, target: project)
   end
 
   it 'test_that_we_can_get_the_previous_value_of_an_edit' do

--- a/test/models/manage_test.rb
+++ b/test/models/manage_test.rb
@@ -59,7 +59,7 @@ class ManageTest < ActiveSupport::TestCase
   end
 
   it 'test active manager fails if deleted' do
-    manage = Manage.create!(account: @admin, target: @proj1, deleted_at: Time.now.utc)
+    manage = Manage.create!(account: @admin, target: @proj1, deleted_at: Time.current)
     manage.update_attributes!(approver: @user1)
     @proj1.reload.active_managers.wont_include(@admin)
   end
@@ -112,7 +112,7 @@ class ManageTest < ActiveSupport::TestCase
 
   it 'test destroy_by! fails if destroyer deleted' do
     # make user an admin
-    manage1 = Manage.create!(account: @user1, target: @proj1, deleted_at: Time.now.utc)
+    manage1 = Manage.create!(account: @user1, target: @proj1, deleted_at: Time.current)
     manage1.update_attributes!(approver: @user1)
 
     # create a manage entry for admin

--- a/test/models/name_fact_test.rb
+++ b/test/models/name_fact_test.rb
@@ -11,9 +11,9 @@ class NameFactTest < ActiveSupport::TestCase
   end
 
   it '#<=> operator' do
-    nf2 = create(:name_fact, last_checkin: Time.now - 2.days)
-    nf3 = create(:name_fact, last_checkin: Time.now - 3.days)
-    nf1 = create(:name_fact, last_checkin: Time.now - 1.days)
+    nf2 = create(:name_fact, last_checkin: Time.current - 2.days)
+    nf3 = create(:name_fact, last_checkin: Time.current - 3.days)
+    nf1 = create(:name_fact, last_checkin: Time.current - 1.days)
     nf4 = create(:name_fact, last_checkin: nil)
 
     [nf4, nf2, nf1, nf3].sort.map(&:id).must_equal [nf1.id, nf2.id, nf3.id, nf4.id]

--- a/test/models/organization_test.rb
+++ b/test/models/organization_test.rb
@@ -67,7 +67,7 @@ class OrganizationTest < ActiveSupport::TestCase
 
   describe 'sort_by_recent' do
     it 'org' do
-      org_1 = create(:organization, name: 'test1', updated_at: Time.now + 5.days)
+      org_1 = create(:organization, name: 'test1', updated_at: Time.current + 5.days)
       org_2 = create(:organization, name: 'test2')
 
       Organization.sort_by_recent.must_equal [org_1, org_2]

--- a/test/models/password_reset_test.rb
+++ b/test/models/password_reset_test.rb
@@ -50,8 +50,8 @@ class PasswordResetTest < ActiveSupport::TestCase
 
     it 'must set a timestamp for expiration' do
       timestamp = account.reset_password_tokens.values.first
-      timestamp.must_be :<=, Time.now.utc.advance(hours: 4)
-      timestamp.must_be :>, Time.now.utc.advance(hours: 3, minutes: 58)
+      timestamp.must_be :<=, Time.current.advance(hours: 4)
+      timestamp.must_be :>, Time.current.advance(hours: 3, minutes: 58)
     end
   end
 end

--- a/test/models/person_test.rb
+++ b/test/models/person_test.rb
@@ -195,7 +195,7 @@ class PersonTest < ActiveSupport::TestCase
     position = nil
     assert_no_difference 'Person.count' do
       position = Position.create!(account: accounts(:kyle), project: projects(:linux),
-                                  start_date: Time.now, stop_date: Time.now)
+                                  start_date: Time.current, stop_date: Time.current)
     end
     assert_no_difference 'Person.count' do
       position.destroy
@@ -220,7 +220,7 @@ class PersonTest < ActiveSupport::TestCase
     name_id = position.name_id
     Person.find_by(project: position.project, name: name_id).must_be_nil
     assert_difference 'Person.count', +1 do
-      position.update(name: nil, start_date: Time.now, stop_date: Time.now)
+      position.update(name: nil, start_date: Time.current, stop_date: Time.current)
     end
     Person.find_by(project_id: position.project_id, name_id: name_id).must_be :present?
   end
@@ -233,7 +233,7 @@ class PersonTest < ActiveSupport::TestCase
     Person.find_by(project_id: position.project_id, name_id: before_name_id).must_be_nil
     Person.find_by(project_id: position.project_id, name_id: after_name_id).must_be :present?
     assert_no_difference 'Person.count' do
-      position.update(name_id: after_name_id, start_date: Time.now, stop_date: Time.now)
+      position.update(name_id: after_name_id, start_date: Time.current, stop_date: Time.current)
     end
     Person.find_by(project_id: position.project_id, name_id: before_name_id).must_be :present?
     Person.find_by(project_id: position.project_id, name_id: after_name_id).must_be_nil

--- a/test/models/position_test.rb
+++ b/test/models/position_test.rb
@@ -169,7 +169,7 @@ class PositionTest < ActiveSupport::TestCase
     it 'must return current utc time when ongoing' do
       position = Position.new(ongoing: true)
       Time.stub :now, stub(utc: 1.minute.ago) do
-        position.effective_stop_date.must_equal Time.now.utc
+        position.effective_stop_date.must_equal Time.current
       end
     end
 
@@ -177,8 +177,8 @@ class PositionTest < ActiveSupport::TestCase
       position = Position.new
       name_fact = stub(active?: true)
       position.stubs(:name_fact).returns(name_fact)
-      Time.stub :now, stub(utc: 1.minute.ago) do
-        position.effective_stop_date.must_equal Time.now.utc
+      Time.stub :current, stub(utc: 1.minute.ago) do
+        position.effective_stop_date.must_equal Time.current
       end
     end
 
@@ -186,8 +186,8 @@ class PositionTest < ActiveSupport::TestCase
       position = Position.new
       name_fact = stub(last_checkin: 1.day.ago)
       position.stubs(:name_fact).returns(name_fact)
-      Time.stub :now, 1.day.ago do
-        position.effective_stop_date.to_i.must_equal Time.now.to_i
+      Time.stub :current, 1.day.ago do
+        position.effective_stop_date.to_i.must_equal Time.current.to_i
       end
     end
   end

--- a/test/models/property_edit_test.rb
+++ b/test/models/property_edit_test.rb
@@ -6,10 +6,10 @@ class PropertyEditTest < ActiveSupport::TestCase
   before do
     project = create(:project, description: 'Linux')
     Edit.for_target(project).delete_all
-    @undone_edit = create(:property_edit, value: 'Spammy!', created_at: Time.now + 5.days, target: project,
-                                          undone: true, undone_at: Time.now + 5.days, undone_by: create(:admin).id)
+    @undone_edit = create(:property_edit, value: 'Spammy!', created_at: Time.current + 5.days, target: project,
+                                          undone: true, undone_at: Time.current + 5.days, undone_by: create(:admin).id)
     @edit = create(:property_edit, value: 'Linux', target: project)
-    @previous_edit = create(:property_edit, value: '456', created_at: Time.now - 5.days, target: project)
+    @previous_edit = create(:property_edit, value: '456', created_at: Time.current - 5.days, target: project)
   end
 
   it 'test_undo_fails_with_no_editor' do

--- a/test/models/recently_active_accounts_cache_test.rb
+++ b/test/models/recently_active_accounts_cache_test.rb
@@ -8,7 +8,7 @@ class RecentlyActiveAccountsCacheTest < ActiveSupport::TestCase
     end
 
     it 'should retrive the first record' do
-      name_facts(:vitafact).update_attributes(last_checkin: Time.now)
+      name_facts(:vitafact).update_attributes(last_checkin: Time.current)
       RecentlyActiveAccountsCache.recalc!
       RecentlyActiveAccountsCache.accounts.count.must_equal 1
     end


### PR DESCRIPTION
`Time.now` returns time in system timezone. Inconsistent usage of
`Time.now` and `Time.now.utc` can lead to unexpected bugs.

For e.g. A test passing on a machine with utc time, might fail when it
is run on machine set to another time zone. We had the tests in
`models/commit_history_chart_test` failing for this reason. The
`commits` factory used `Time.now.beginning_of_month`. On a machine with
time zone having positive utc offset, this would return the last day of
previous month in utc.

The current `Time.zone` is set to UTC by default, so we can consistently
use `Time.current` everywhere. Using `Time.current` will also help if we
decide to change the timezone per request based on user's location in
future.
