### PR TITLE
OTWO-3712: Fix random ImageMagick failures

### DIFF
--- a/lib/widget_badge/partner.rb
+++ b/lib/widget_badge/partner.rb
@@ -10,6 +10,8 @@ module WidgetBadge
                              align: :center, y_offset: 0 }
 
     def create(image_data)
+      GC.start
+
       tempfile = Tempfile.new(['partner-badge', '.gif'])
       animate(*image_data, tempfile.path)
       image = MiniMagick::Image.open(tempfile.path)

--- a/lib/widget_badge/thin.rb
+++ b/lib/widget_badge/thin.rb
@@ -7,6 +7,8 @@ module WidgetBadge
     include BadgeHelper
 
     def create(image_data)
+      GC.start
+
       tempfile = Tempfile.new(['thin-badge', '.gif'])
       animate(*image_data, tempfile.path)
       image = MiniMagick::Image.open(tempfile.path)


### PR DESCRIPTION
Ruby's GC deletes closed files periodically. Our code creates a number
of images using tempfiles and merges them into a GIF. Occasionally,
ruby's GC deletes some of these tempfiles right before we use it for
creating the GIF. This causes the missing tmp file exception.

Manually setting GC.start beforehand ensures that the garbage collection
does not happen during the timeframe in which the widget is created.
