### PR TITLE
OTWO-3777: Add metadata routes for all our widgets

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,12 @@
 # This file is used by Rack-based servers to start the application.
 
 require ::File.expand_path('../config/environment',  __FILE__)
+
+if defined?(PhusionPassenger)
+  PhusionPassenger.require_passenger_lib 'rack/out_of_band_gc'
+
+  # Trigger out-of-band GC every 5 requests.
+  use PhusionPassenger::Rack::OutOfBandGc, 5
+end
+
 run Rails.application


### PR DESCRIPTION
…t Ruby's GC from being invoked in the middle of a request/response cycle. This generally improves performance, but we're hoping it also stops the temp files from being deleted in the middle of a widget being generated.
