### PR TITLE
OTWO-3716: Allow access to edits page for deleted project

### DIFF
--- a/app/controllers/edits_controller.rb
+++ b/app/controllers/edits_controller.rb
@@ -33,7 +33,7 @@ class EditsController < SettingsController
 
   def find_project
     return nil unless params[:project_id]
-    Project.from_param(params[:project_id]).take
+    Project.by_url_name_or_id(params[:project_id]).take
   end
 
   def find_organization


### PR DESCRIPTION
We do allow access to the edits page for deleted projects in the old source. 
