### PR TITLE
Don't notify Airbrake about exceptions from poorly crafted bots.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,7 +30,7 @@ class ApplicationController < ActionController::Base
 
   rescue_from ::Exception do |exception|
     fail exception if Rails.application.config.consider_all_requests_local
-    notify_airbrake(exception)
+    notify_airbrake(exception) unless blank_user_agent?
     render_404
   end
 
@@ -165,6 +165,10 @@ class ApplicationController < ActionController::Base
 
   def bot?
     (request.env['HTTP_USER_AGENT'] =~ BOT_REGEX).present?
+  end
+
+  def blank_user_agent?
+    request.env['HTTP_USER_AGENT'].blank?
   end
 
   def show_permissions_alert

--- a/app/models/contribution.rb
+++ b/app/models/contribution.rb
@@ -32,7 +32,7 @@ class Contribution < ActiveRecord::Base
   end
 
   def kudoable
-    person.account || self
+    (person && person.account) || self
   end
 
   def recent_kudos(limit = 3)

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -78,6 +78,15 @@ class ApplicationControllerTest < ActionController::TestCase
       Rails.application.config.unstub(:consider_all_requests_local)
     end
 
+    it 'does not invoke airbrake if the user agent string has been set to blank (discount, often buggy bots)' do
+      request.env.delete 'HTTP_USER_AGENT'
+      Rails.application.config.stubs(:consider_all_requests_local).returns false
+      @controller.expects(:notify_airbrake).never
+      get :throws_standard_error
+      must_respond_with :not_found
+      Rails.application.config.unstub(:consider_all_requests_local)
+    end
+
     it 'does not prevent sandard errors from being shown to developers' do
       Rails.application.config.stubs(:consider_all_requests_local).returns true
       @controller.expects(:notify_airbrake).never


### PR DESCRIPTION
Fix possible nil dereference.
