### PR TITLE
OTWO-3802: As unique constraint violations throw errors even when not using the …

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -15,12 +15,11 @@ class OrganizationsController < ApplicationController
 
   def create
     @organization = Organization.new({ editor_account: current_user }.merge(organization_params))
-    if @organization.save
-      redirect_to organization_path(@organization), notice: t('.notice')
-    else
-      flash.now[:error] = t('.error')
-      render :new
-    end
+    @organization.save!
+    redirect_to organization_path(@organization), notice: t('.notice')
+  rescue
+    flash.now[:error] = t('.error')
+    render :new
   end
 
   def edit
@@ -29,14 +28,12 @@ class OrganizationsController < ApplicationController
 
   def update
     return render_unauthorized unless @organization.edit_authorized?
-    if @organization.update_attributes(organization_params)
-      redirect_to organization_path(@organization), notice: t('.notice')
-    else
-      @current_object = @organization.clone
-      @organization.reload
-      flash.now[:error] = t('.failure')
-      render :edit, status: :unprocessable_entity
-    end
+    @organization.update_attributes!(organization_params)
+    redirect_to organization_path(@organization), notice: t('.notice')
+  rescue
+    @current_object = @organization
+    flash.now[:error] = t('.failure')
+    render :edit, status: :unprocessable_entity
   end
 
   def show

--- a/test/controllers/organizations_controller_test.rb
+++ b/test/controllers/organizations_controller_test.rb
@@ -371,6 +371,17 @@ describe 'OrganizationsController' do
       must_redirect_to organization_path(assigns(:organization))
       assigns(:organization).valid?.must_equal true
     end
+
+    it 'should gracefully handle duplicate url_names' do
+      old_org = create(:organization)
+      account.update_column(:level, 10)
+      login_as account
+      post :create, organization: { name: 'test', description: 'tes', url_name: old_org.url_name,
+                                    org_type: '2', homepage_url: 'http://test.com' }
+
+      must_respond_with :ok
+      assigns(:organization).errors[:url_name].must_equal ['has already been taken']
+    end
   end
 
   describe 'update' do


### PR DESCRIPTION
…! versions of save and update_attributes, use the ! versions with rescues.
