### PR TITLE
As Errbit is setting HTTP_USER_AGENT to blank, we need to add another…

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,6 +32,7 @@ class ApplicationController < ActionController::Base
 
   rescue_from ::Exception do |exception|
     fail exception if Rails.application.config.consider_all_requests_local
+    request.env[:user_agent] = request.user_agent
     notify_airbrake(exception) unless blank_user_agent?
     render_404
   end


### PR DESCRIPTION
… environmental var to ensure it appears in Errbit.
