### PR TITLE
OTWO-3867: Default to 'js' as a format as GoogleBot is causing it to default to …

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -149,7 +149,7 @@ Rails.application.routes.draw do
   get 'tools', to: 'abouts#tools'
 
   get 'p/_compare', to: 'compares#projects', as: :compare_projects
-  get 'p/_project_graph', to: 'compares#projects_graph', as: :compare_graph_projects
+  get 'p/_project_graph', to: 'compares#projects_graph', as: :compare_graph_projects, defaults: { format: 'js' }
   get 'projects/:id/stacks', to: 'stacks#project_stacks', constraints: { format: /xml/ }
   get 'p/:id/stacks', to: 'stacks#project_stacks', as: :project_stacks, constraints: { format: /xml/ }
   get 'p/:id/stacks', to: redirect('/p/%{id}/users'), constraints: { format: /html/ }


### PR DESCRIPTION
…html.
