### PR TITLE
OTWO-3887 Fix account logins for invalid characters other than period

### DIFF
--- a/script/replace_period_characters_from_login
+++ b/script/replace_period_characters_from_login
@@ -10,8 +10,8 @@ class LoginChangedNotifier
     end
 
     Account.where("login like '%.%'").each do |account|
-      new_login = account.login.gsub(/\./, '-')
-      account.update!(login: new_login)
+      new_login = account.login.gsub(/[^\w_-]/, '-')
+      account.update_column('login', new_login)
 
       send_email(account) unless Account::Access.new(account).disabled?
     end


### PR DESCRIPTION
Some accounts have login names with url or email address values:
http://chasecc.livejournal.com
fabien@jakimowicz.com

We have to use update_column since some other login values are invalid:
89.com
