### PR TITLE
OTWO-3921 Do not store POST routes in session[:return_to]

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -156,7 +156,7 @@ class ApplicationController < ActionController::Base
   end
 
   def store_location
-    return if request.xhr? || request_format != 'html'
+    return if request.xhr? || request.post? || request_format != 'html'
     session[:return_to] = request.fullpath
   end
 


### PR DESCRIPTION
After signup, we make a **GET** request to the route saved in `session[:return_to]`. **POST** routes would fail in such a scenario.
