### PR TITLE
OTWO-3951 Update code_sets.fetched_at using clumps

### DIFF
--- a/lib/tasks/update_code_set_fetched_at.rake
+++ b/lib/tasks/update_code_set_fetched_at.rake
@@ -1,0 +1,10 @@
+task update_code_set_fetched_at: :environment do
+  ActiveRecord::Base.connection.execute("
+    UPDATE code_sets
+      SET fetched_at = (
+        SELECT MAX(fetched_at)
+          FROM clumps
+          WHERE code_sets.id = clumps.code_set_id
+      )
+  ")
+end


### PR DESCRIPTION
This took 25 seconds to run on staging:

``` sh
deployer@oh-stage-web-3:/var/local/openhub/current$ time RAILS_ENV=staging bundle exec rake update_code_set_fetched_at
real    0m25.297s
user    0m5.113s
sys     0m0.670s
```

``` sql
openhub_development=# select count(*) from code_sets;
 count
--------
 673778
(1 row)

openhub_development=# select count(*) from code_sets where fetched_at is null;
 count
-------
 75114
```
