### PR TITLE
Hot fix topics sort order

### DIFF
--- a/app/models/forum.rb
+++ b/app/models/forum.rb
@@ -3,6 +3,6 @@ class Forum < ActiveRecord::Base
   validates :position, numericality: { only_integer: true }, allow_blank: true
   validates :position, length: { maximum: 9 }
 
-  has_many :topics, -> { order('sticky desc, replied_at desc') }, dependent: :destroy
+  has_many :topics, -> { order('sticky desc, updated_at desc') }, dependent: :destroy
   has_many :posts, through: :topics
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,8 +1,7 @@
 class Post < ActiveRecord::Base
   include Tsearch
-  belongs_to :topic, inverse_of: :posts
   belongs_to :forum, counter_cache: true
-  belongs_to :topic, inverse_of: :posts, counter_cache: true
+  belongs_to :topic, inverse_of: :posts, counter_cache: true, touch: true
   belongs_to :account
 
   validates :body, :topic, presence: true

--- a/script/fix_updated_at_for_topics
+++ b/script/fix_updated_at_for_topics
@@ -1,0 +1,17 @@
+#! /usr/bin/env ruby
+
+require_relative '../config/environment'
+
+class FixUpdatedAtForTopic
+  def execute
+    Topic.find_in_batches.each_with_index do |topic_group, index|
+      puts "Processing batch #{index}"
+      topic_group.each do |topic|
+        last_post_date = topic.posts.maximum(:updated_at)
+        topic.update_column(:updated_at, last_post_date) if last_post_date
+      end
+    end
+  end
+end
+
+FixUpdatedAtForTopic.new.execute

--- a/test/models/forum_test.rb
+++ b/test/models/forum_test.rb
@@ -40,16 +40,16 @@ class ForumTest < ActiveSupport::TestCase
     forum.topics_count.must_equal 0
   end
 
-  it 'forum should have associated topic sorted by sticky and replied at desc' do
+  it 'forum should have associated topic sorted by sticky and updated at desc' do
     forum = create(:forum_with_topics)
-    forum.topics.to_a.must_equal forum.topics.sort_by(&:replied_at).reverse
+    forum.topics.to_a.must_equal forum.topics.sort_by(&:updated_at).reverse
     forum.topics.to_a.must_equal forum.topics.sort_by(&:sticky).reverse
   end
 
-  it 'forum should have associated posts ordered by created at asc' do
+  it 'forum should have associated posts ordered by updated_at at asc' do
     topic = create(:topic_with_posts)
     forum = topic.forum
-    forum.posts.to_a.must_equal forum.posts.sort_by(&:created_at)
+    forum.posts.to_a.reverse.must_equal forum.posts.sort_by(&:updated_at)
   end
 
   it 'destroying a forum destroys its accompanying topics and posts' do


### PR DESCRIPTION
Change the order of topics to created_at instead of replied_at.
