### PR TITLE
Fix the definition of failed? for a Repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ tags
 .env.development
 .env.test
 .env
+.byebug_history

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -28,7 +28,7 @@ class Repository < ActiveRecord::Base
   end
 
   def failed?
-    job = jobs.incomplete.first
+    job = jobs.order(:current_step_at).reverse.first
     job.failed?
   end
 

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -19,6 +19,33 @@ class RepositoryTest < ActiveSupport::TestCase
     end
   end
 
+  describe 'failed?' do
+    before do
+      @repository = create(:repository)
+      @repository.jobs.clear
+      @job1 = create(:complete_job)
+      @job2 = create(:complete_job)
+    end
+
+    it 'show be true when the most recent job has failed' do
+      @job1.update(repository: @repository, current_step_at: 2.days.ago, status: Job::STATUS_COMPLETED)
+      @job2.update(repository: @repository, current_step_at: 5.minutes.ago, status: Job::STATUS_FAILED)
+      @repository.failed?.must_equal true 
+    end
+
+    it 'must be false when all jobs have completed' do
+      @job1.update(repository: @repository, current_step_at: 2.days.ago, status: Job::STATUS_COMPLETED)
+      @job2.update(repository: @repository, current_step_at: 5.minutes.ago, status: Job::STATUS_COMPLETED)
+      @repository.failed?.must_equal false
+    end
+
+    it 'must be false when there is a scheduled job' do
+      @job1.update(repository: @repository, current_step_at: 2.days.ago, status: Job::STATUS_COMPLETED)
+      @job2.update(repository: @repository, current_step_at: nil, status: Job::STATUS_SCHEDULED)
+      @repository.failed?.must_equal false
+    end
+  end
+
   describe 'bypass_url_validation=' do
     it 'must set value to false for 0' do
       repository = Repository.new(bypass_url_validation: '0')


### PR DESCRIPTION
There was a problem with the Ohloh implementation of failed? for a
Repository in that the order of a set of Jobs for a Repo was undefined,
and the code would take the first one and check to see if it had failed.
There was no guarantee that the first Job was the most recent.
We carried that forward.

And, we added a new defect in that we were not accounting for the
situation wherein all the jobs could have been completed.  In that case,
we had an empty array and "failed?" was called on the NilClass.

This change ensures ordering of the jobs and includes jobs in every
state.
