### PR TITLE
Add Job status to tool tip

### DIFF
--- a/app/views/admin/dashboard/_failed.html.arb
+++ b/app/views/admin/dashboard/_failed.html.arb
@@ -3,7 +3,7 @@ slave.jobs.failed
   .order(:status, :id).limit(20)
   .each_with_index do |job, i|
     a href: admin_job_path(job), style:"text-decoration:none;" do
-      status_tag("#{job.class.to_s.first} #{job.id}", :no, title: job.current_step_at)
+      status_tag("#{job.class.to_s.first} #{job.id}", 'failed', title: JobDecorator.new(job).tool_tip)
     end
     br if i.odd?
 end

--- a/test/integration/admin/dashboard_admin_test.rb
+++ b/test/integration/admin/dashboard_admin_test.rb
@@ -4,25 +4,24 @@ require 'test_helpers/admin_test_helper'
 class DashboardAdminTest < ActionDispatch::IntegrationTest
   include AdminTestHelper
 
-  it 'renders the dashbord' do
+  before do
     LoadAverage.create(current: 4.8)
     create_and_login_admin
+  end
+
+  it 'renders the dashbord' do
     create(:fetch_job, status: Job::STATUS_RUNNING, current_step_at: Time.current)
     get admin_root_path
     assert_response :success
   end
 
   it 'renders the Overviews' do
-    LoadAverage.create(current: 4.8)
-    create_and_login_admin
     get admin_root_path
     assert_select 'h3', text: 'Overview Statistics'
     assert_select 'h3', text: 'Job Overview'
   end
 
   it 'should list different time windows' do
-    LoadAverage.create(current: 4.8)
-    create_and_login_admin
     get admin_root_path
     assert_select "div[class='panel_contents']" do
       assert_select 'a', text: 'Ten Minutes'
@@ -35,5 +34,22 @@ class DashboardAdminTest < ActionDispatch::IntegrationTest
       assert_select 'a', text: 'One Month'
       assert_select 'a', text: 'All'
     end
+  end
+
+  it 'shows the slaves' do
+    Slave.delete_all
+    slave = create(:slave)
+    get admin_root_path
+    assert_select "a[href='/admin/slaves/#{slave.id}']", text: slave.hostname
+    assert_select 'span.allow', text: 'Allow'
+    assert_select 'td.col-load_average', text: slave.load_average.to_s
+  end 
+
+  it 'shows the jobs' do
+    Slave.delete_all
+    slave = create(:slave)
+    job = create(:complete_job, {slave: slave, status: Job::STATUS_RUNNING, current_step_at: Time.now() - 10.minutes})
+    get admin_root_path
+    assert_select "a[href='/admin/jobs/#{job.id}']", text:"C #{job.id}"
   end
 end


### PR DESCRIPTION
This commit adds the Job status message to the tool tip for failed jobs
and changes the color of the failed job from the ActiveAdmin standard
"no" to the traditional red color used on the old UI.

Additionally, more tests were added.  :-)
