### PR TITLE
OTWO-4128: Fix code_set clump sort

### DIFF
--- a/app/models/code_set.rb
+++ b/app/models/code_set.rb
@@ -14,12 +14,12 @@ class CodeSet < ActiveRecord::Base
     analysis_sloc_set.nil? ? CodeSet.none : analysis_sloc_set.ignore_prefixes
   end
 
-  # impmentation that should be used when clumps are removed
+  # Implementation that should be used when clumps are removed
   # def reimport
   #   ImportJob.create!(code_set: CodeSet.create!(repository_id: repository_id))
   # end
 
-  # AFter clumps are remvoed, delete from here ....
+  # After clumps are removed, delete from here ....
   def reimport
     old_clump.slave.run_local_or_remote("mv #{old_clump.path} #{new_clump.path}")
     return ImportJob.create(code_set: new_code_set) if old_clump.delete

--- a/test/models/code_set_test.rb
+++ b/test/models/code_set_test.rb
@@ -6,8 +6,8 @@ describe CodeSet do
 
   describe 'reimport' do
     it 'should create a new code set, clump and import job' do
-      # clone the most recently udpated clump, which we want to be the factory created one.
-      # # So make one more older GitClump
+      # Clone the most recently updated clump, which we want to be the factory created one.
+      # So make one more older GitClump to test the sort.
       code_set.clumps << GitClump.create(slave: Slave.first)
       code_set.clumps.last.update_attribute(:updated_at, clump.updated_at - 2.days)
       Slave.any_instance.stubs(:run_local_or_remote).returns(true)


### PR DESCRIPTION
The sort method does not take a reference to a method as an argument, so
the "Re-Import" functionality in the UI has been failing.
