### PR TITLE
OTWO-4129  Add Optimizely tracking code

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -14,6 +14,7 @@
     = csrf_meta_tags
     = javascript_include_tag 'https://www.google.com/recaptcha/api.js'
     = javascript_include_tag 'https://cdn.digits.com/1/sdk.js'
+    = javascript_include_tag '//cdn.optimizely.com/js/3568250046.js'
     - if Rails.env.production?
       <script type="text/javascript">
       (function() {


### PR DESCRIPTION
Marketing would like to track user behavior and demographic on the Open
Hub and has asked that we add this tracking code.

Note: Since this code is available on the public website for anyone
sufficiently clever enough to use "view source", there really isn't much
benefit from hiding this value in an environment variable.
