### PR TITLE
OTWO-4093 Modified middleware to achieve gzip compression

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,8 @@ Dotenv.load '.env.local', ".env.#{Rails.env}"
 
 module OhlohUi
   class Application < Rails::Application
+    config.middleware.use Rack::Deflater
+
     config.generators.stylesheets = false
     config.generators.javascripts = false
     config.generators.helper = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -26,7 +26,7 @@ Rails.application.configure do
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier
-  # config.assets.css_compressor = :sass
+  config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false

--- a/test/integration/compression_test.rb
+++ b/test/integration/compression_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class CompressionTest < ActionDispatch::IntegrationTest
+  describe 'when a visitor has a browser that supports compression' do
+    it 'responds with a deflate/gzip content-encoding' do
+      ['deflate', 'gzip', 'deflate,gzip', 'gzip,deflate'].each do |compression_method|
+        get root_path, {}, ({ 'HTTP_ACCEPT_ENCODING' => compression_method })
+        assert_includes %w(deflate gzip), response.headers['Content-Encoding']
+      end
+    end
+  end
+
+  describe 'when a visitor\'s browser does not support compression' do
+    it 'doesn\'t responds with a deflate/gzip content-encoding' do
+      get root_path
+      assert_equal nil, response.headers['Content-Encoding']
+    end
+  end
+end


### PR DESCRIPTION
Modified middleware to respond a web request with gzip content-encoding to achive compression and enhance page speed.

Also added integration test cases for the same.
