### PR TITLE
Manually submit new enlistment form

### DIFF
--- a/app/assets/javascripts/enlistments.js.coffee
+++ b/app/assets/javascripts/enlistments.js.coffee
@@ -34,8 +34,10 @@ App.Enlistment = init: ->
         $('.bzr input').removeAttr('disabled')
   ).change()
 
-  $('.enlistment .submit').one 'click', ->
+  $('.enlistment .submit').click ->
     $(this).attr('disabled', 'disabled')
     $('.enlistment .spinner').show()
+    $('.well.enlistment form').submit()
+
 $(document).on 'page:change', ->
   App.Enlistment.init()


### PR DESCRIPTION
With the change in OTWO-4017, we are correctly disabling the submit
button to prevent double-taps that could create more than one
enlistment.  However, the disabled submit button seems to suppress form
submission.

The corrective action would be to manually trigger the submit() action.
This would be as straight-forward as using the ID of the form.

The issue with that is the form ID will change.  It will start as
"new_repository", but if there is an error, the form ID changes to
`new_<type>_repository`.  Therefore, a different selector was needed.

This change uses the assumption that the class ".well.enlistment" will
always have the form that needs to be submitted.
