### PR TITLE
OTWO-3657 Added meaningful titles to all required pages

### DIFF
--- a/app/views/accounts/edit.html.haml
+++ b/app/views/accounts/edit.html.haml
@@ -1,5 +1,5 @@
 - page_context[:select_footer_nav] = :settings
-- content_for(:html_title) { t('accounts.show.page_title', name: @account.name) }
+- content_for(:html_title) { t('accounts.edit.page_title', name: @account.name) }
 
 .clearfix
 

--- a/config/locales/accounts.en.yml
+++ b/config/locales/accounts.en.yml
@@ -19,7 +19,7 @@ en:
       settings: '&nbsp; Settings'
     languages:
       index:
-        page_title: "%{name} : %{name} - Open Hub"
+        page_title: "%{name} : Languages - Open Hub"
         title: 'Languages'
       commits_by_language:
         title: 'Languages'
@@ -36,6 +36,7 @@ en:
         success: "The account %{name} has been marked as spammer."
 
     edit:
+      page_title: '%{name} : Account Basics - Open Hub'
       email_help: 'We use your email address to show your'
       affiliation_help: "Enter the company or organization you're affiliated with."
       city_and_country: 'City &amp; Country'
@@ -86,7 +87,7 @@ en:
       in: 'in ...'
       to: 'to ...'
     show:
-      page_title: '%{name} : %{name} - Open Hub'
+      page_title: '%{name} - Open Hub'
       total_commits: 'total commits'
       project: 'project'
       analysis_scheduled: 'The analysis for this account has been scheduled.'

--- a/config/locales/kudos.en.yml
+++ b/config/locales/kudos.en.yml
@@ -11,7 +11,7 @@ en:
     undo_account: "Are you sure you want to delete kudos received from %{from}?"
     for: "(for %{what})"
     index:
-      page_title: "%{name} : %{name} - Open Hub"
+      page_title: "%{name} : Kudos - Open Hub"
       title: "Kudos"
       kudos_received: "Kudos Received"
       no_kudos_received_yet: "No kudos received yet."

--- a/config/locales/passwords.en.yml
+++ b/config/locales/passwords.en.yml
@@ -10,7 +10,7 @@ en:
               confirmation: "Please enter the same password in the confirmation field."
   passwords:
     edit:
-      edit_password_title: '%{account} : %{account} - Open Hub'
+      edit_password_title: '%{account} : Password Settings - Open Hub'
       settings_password_html: '%{href} : Password'
       settings: 'Settings'
       change_your_password: 'Change Your Password'

--- a/config/locales/positions.en.yml
+++ b/config/locales/positions.en.yml
@@ -3,7 +3,7 @@ en:
     create:
       invite_success: "Congrats! You've created a Black Duck Open Hub account and claimed your contribution. Consider adding some information about yourself by clicking 'Profile' under your name at the top of this page. You can also build a list of the open source projects you use by clicking on the Stack link."
     index:
-      page_title: "%{name} : %{name} - Open Hub"
+      page_title: "%{name} : Positions - Open Hub"
       contributions_on_open_hub: "%{name}'s Developer Contributions on Open Hub."
       no_contributions_to_display: There are no contributions available to display.
       claim_contribution: Claim a Contribution
@@ -14,7 +14,7 @@ en:
       position_new_title: '%{name} : Open Hub'
       contribution: 'Contributions'
     edit:
-      edit_title: '%{name} : %{name} - Open Hub'
+      edit_title: '%{name} : Edit Contribution - Open Hub'
     commit_information:
       in_mostly: 'in mostly'
     commits_by_individual_projects:

--- a/config/locales/privacy.en.yml
+++ b/config/locales/privacy.en.yml
@@ -1,7 +1,7 @@
 en:
   privacy:
     edit:
-      edit_privacy_title: '%{account} : %{account} - Open Hub'
+      edit_privacy_title: '%{account} : Privacy Settings - Open Hub'
       settings_privacy_html: '%{href} : Privacy'
       settings: 'Settings'
       manage_email: 'Manage email from Open Hub'

--- a/config/locales/stacks.en.yml
+++ b/config/locales/stacks.en.yml
@@ -8,7 +8,7 @@ en:
     gnome: 'GNOME Desktop'
     gnome_desc: 'GNOME, Firefox, OpenOffice.org, Thunderbird, and GIMP'
     index:
-      page_title: "%{name} : %{name}'s Stacks - Open Hub"
+      page_title: "%{name}'s Stacks - Open Hub"
       new_stack: "New Stack"
       embed: "Embed"
       remove: "Remove"


### PR DESCRIPTION
Added the required meaningful titles to the user's setting pages, stacks, kudos, positions and languages in the format of `<login> : <relevant title> - Open Hub`
