### PR TITLE
OTWO-3657 Changed the page title for user's stacks and setting pages

### DIFF
--- a/config/locales/accounts.en.yml
+++ b/config/locales/accounts.en.yml
@@ -159,7 +159,7 @@ en:
       disabled_account: "%{user}'s account is disabled."
       disabled_message: 'This account has been disabled. If you are the account owner and wish to discuss this, send email to info@openhub.net.'
     settings:
-      settings_title: '%{name} : Settings Page - Open Hub'
+      settings_title: '%{name} : Settings - Open Hub'
       settings: 'Settings'
       account_basics: 'Account Basics'
       password: 'Password'

--- a/config/locales/stacks.en.yml
+++ b/config/locales/stacks.en.yml
@@ -8,7 +8,7 @@ en:
     gnome: 'GNOME Desktop'
     gnome_desc: 'GNOME, Firefox, OpenOffice.org, Thunderbird, and GIMP'
     index:
-      page_title: "%{name}'s Stacks - Open Hub"
+      page_title: "%{name} : Stacks - Open Hub"
       new_stack: "New Stack"
       embed: "Embed"
       remove: "Remove"


### PR DESCRIPTION
Modified page title for user's stacks and setting pages with the new format `<login> : <relevant title> - Open Hub` to retain uniformity.
