### PR TITLE
[OTWO-4172] Fix for polling queue breakage

### DIFF
--- a/lib/reverification/amazon.rb
+++ b/lib/reverification/amazon.rb
@@ -1,0 +1,29 @@
+module Reverification
+  module Amazon
+    PILOT_AMOUNT = 5000
+    def ses
+      @ses ||= AWS::SimpleEmailService.new
+    end
+
+    def sqs
+      @sqs ||= AWS::SQS.new
+    end
+
+    def success_queue
+      @success_queue ||= sqs.queues.named('ses-success-queue')
+    end
+
+    def bounce_queue
+      @bounce_queue ||= sqs.queues.named('ses-bounces-queue')
+    end
+
+    def complaints_queue
+      @complaints_queue ||= sqs.queues.named('ses-complaints-queue')
+    end
+
+    def ses_daily_limit_available
+      quotas = ses.quotas
+      PILOT_AMOUNT - quotas[:sent_last_24_hours]
+    end
+  end
+end

--- a/lib/reverification/process.rb
+++ b/lib/reverification/process.rb
@@ -1,39 +1,7 @@
 module Reverification
-  # rubocop:disable ClassLength
   class Process
-    PILOT_AMOUNT = 5000
+    extend Amazon
     class << self
-      def ses
-        @ses ||= AWS::SimpleEmailService.new
-      end
-
-      def sqs
-        @sqs ||= AWS::SQS.new
-      end
-
-      def success_queue
-        @success_queue ||= sqs.queues.named('ses-success-queue')
-      end
-
-      def bounce_queue
-        @bounce_queue ||= sqs.queues.named('ses-bounces-queue')
-      end
-
-      def complaints_queue
-        @complaints_queue ||= sqs.queues.named('ses-complaints-queue')
-      end
-
-      # Note: this method is not used anywhere but might be needed for later.
-      def ses_limit_reached?
-        quotas = ses.quotas
-        quotas[:sent_last_24_hours] == quotas[:max_24_hour_send]
-      end
-
-      def ses_daily_limit_available
-        quotas = ses.quotas
-        PILOT_AMOUNT - quotas[:sent_last_24_hours]
-      end
-
       def statistics_of_last_24_hrs
         ses.statistics.find_all { |s| s[:sent].between?(Time.now.utc - 24.hours, Time.now.utc) }
       end
@@ -47,7 +15,8 @@ module Reverification
         bounce_rate = sent_last_24_hrs.zero? ? 0.0 : (no_of_bounces / sent_last_24_hrs) * 100
         complaint_rate = sent_last_24_hrs.zero? ? 0.0 : (no_of_complaints / sent_last_24_hrs) * 100
         handler_ns = Reverification::ExceptionHandlers
-        fail(handler_ns::BounceRateLimitError, 'Bounce Rate exceeded 5%') if bounce_rate >= 5.0
+        # This needs to be changed back to 5% after initial pilot
+        fail(handler_ns::BounceRateLimitError, 'Bounce Rate exceeded 5%') if bounce_rate >= 20.0
         fail(handler_ns::ComplaintRateLimitError, 'Complaint Rate exceeded 0.1%') if complaint_rate >= 0.1
       end
       # rubocop:enable Metrics/AbcSize
@@ -124,5 +93,4 @@ module Reverification
       end
     end
   end
-  # rubocop:enable ClassLength
 end

--- a/test/lib/reverification/process_test.rb
+++ b/test/lib/reverification/process_test.rb
@@ -206,12 +206,6 @@ class Reverification::ProcessTest < ActiveSupport::TestCase
     end
   end
 
-  describe 'ses_limit_reached?' do
-    it 'should return false when daily sent quota not reached max daily send quota' do
-      assert_equal false, Reverification::Process.ses_limit_reached?
-    end
-  end
-
   describe 'ses_daily_limit_available' do
     it 'should return the balance send limit available for the day' do
       assert_equal 4950, Reverification::Process.ses_daily_limit_available
@@ -219,7 +213,8 @@ class Reverification::ProcessTest < ActiveSupport::TestCase
   end
 
   describe 'check_statistics_of_last_24_hrs' do
-    it 'should raise SimpleEmailServieLimitError if bounce rate is above 5%' do
+    # This needs to changed back to 5% once initial testing is complete
+    it 'should raise SimpleEmailServieLimitError if bounce rate is above 20%' do
       over_bounce_limit = MOCK::AWS::SimpleEmailService.over_bounce_limit
       AWS::SimpleEmailService.any_instance.stubs(:statistics).returns(over_bounce_limit)
       # 3 bounces in over_bounce_limit would be 5% of 60 total sent emails
@@ -229,7 +224,8 @@ class Reverification::ProcessTest < ActiveSupport::TestCase
       end
     end
 
-    it 'should not raise SimpleEmailServieLimitError if bounce rate is below 5%' do
+    # This needs to changed back to 5% once initial testing is complete
+    it 'should not raise SimpleEmailServieLimitError if bounce rate is below 20%' do
       under_bounce_limit = MOCK::AWS::SimpleEmailService.under_bounce_limit
       AWS::SimpleEmailService.any_instance.stubs(:statistics).returns(under_bounce_limit)
       AWS::SimpleEmailService.any_instance.stubs(:quotas).returns(sent_last_24_hours: 60)

--- a/test/test_helpers/reverification.rb
+++ b/test/test_helpers/reverification.rb
@@ -19,7 +19,7 @@ module MOCK
         end
 
         def over_bounce_limit
-          [{ sent: Time.now.utc - 10.hours, delivery_attempts: 0, rejects: 0, bounces: 1, complaints: 0 },
+          [{ sent: Time.now.utc - 10.hours, delivery_attempts: 0, rejects: 0, bounces: 15, complaints: 0 },
            { sent: Time.now.utc - 8.hours, delivery_attempts: 0, rejects: 0, bounces: 2, complaints: 0 },
            { sent: Time.now.utc - 3.hours, delivery_attempts: 0, rejects: 0, bounces: 6, complaints: 0 }]
         end


### PR DESCRIPTION
Skip to iterate next feedback notification when reverification tracker doesn't exists for the account
