### PR TITLE
Amazon Throttling Error handling

### DIFF
--- a/lib/reverification/process.rb
+++ b/lib/reverification/process.rb
@@ -23,6 +23,7 @@ module Reverification
 
       def send_email(template, account, phase)
         check_statistics_of_last_24_hrs
+        sleep(3)
         resp = ses.send_email(template)
         if account.reverification_tracker
           update_tracker(account.reverification_tracker, phase, resp)


### PR DESCRIPTION
Introduces a call to sleep in order to prevent Amazon Throttling errors
