### PR TITLE
[OTWO-4173] Fix authorization error to edit alias of unverified account

### DIFF
--- a/app/models/reverification_tracker.rb
+++ b/app/models/reverification_tracker.rb
@@ -43,11 +43,14 @@ class ReverificationTracker < ActiveRecord::Base
 
     def destroy_account(email_address)
       account = Account.find_by_email(email_address)
-      account.destroy if account
+      return unless account
+      account.access.spam!
+      account.destroy
     end
 
     def delete_expired_accounts
       expired_final_phase_notifications.each do |rev_tracker|
+        rev_tracker.account.access.spam!
         rev_tracker.account.destroy
       end
     end

--- a/lib/reverification/process.rb
+++ b/lib/reverification/process.rb
@@ -23,7 +23,7 @@ module Reverification
 
       def send_email(template, account, phase)
         check_statistics_of_last_24_hrs
-        sleep(3)
+        sleep(1)
         resp = ses.send_email(template)
         if account.reverification_tracker
           update_tracker(account.reverification_tracker, phase, resp)

--- a/test/models/reverification_tracker_test.rb
+++ b/test/models/reverification_tracker_test.rb
@@ -222,6 +222,12 @@ class ReverificationTrackerTest < ActiveSupport::TestCase
       Account.any_instance.expects(:destroy).never
       ReverificationTracker.destroy_account(@account.email)
     end
+
+    it 'should convert the account as spam before delete it' do
+      Account.any_instance.stubs(:destroy).returns(nil)
+      ReverificationTracker.destroy_account(@account.email)
+      assert @account.reload.access.spam?
+    end
   end
 
   describe 'delete_expired_accounts' do


### PR DESCRIPTION
Fixed authorization error to edit alias of unverified account.
Reduced the waiting time to 1 second to avoid awss throttling error
