### PR TITLE
[OTWO-4159] Correct displaying different values in tooltip and label in project demographics chart

### DIFF
--- a/config/charting/demographic.yml
+++ b/config/charting/demographic.yml
@@ -30,7 +30,7 @@ plotOptions:
       minSize: 1
       color: '#000000'
       connectorColor: '#000000'
-      format: '<b>{point.name}</b>: {point.percentage:.1f} %'
+      format: '<b>{point.name}</b>: {point.y} %'
 credits:
   enabled: false
 series: [{type: 'pie'}]


### PR DESCRIPTION
Currently in project demographics chart, activity level percentage value is not identical in chart label and tooltip and it is fixed now by picking up correct attribute from the response json data.
