### PR TITLE
OTWO-4198 Added sort option for job_count in failure groups admin page

### DIFF
--- a/test/integration/admin/failure_group_admin_test.rb
+++ b/test/integration/admin/failure_group_admin_test.rb
@@ -25,6 +25,24 @@ class FailureGroupAdminTest < ActionDispatch::IntegrationTest
     assert_response :ok
   end
 
+  describe 'index' do
+    it 'should render failure groups sorted in ascending order' do
+      failure_group = create(:failure_group)
+      create(:failed_job, failure_group_id: failure_group.id)
+      login_as admin
+      get admin_failure_groups_path(order: 'job_count_asc')
+      assert_response :ok
+    end
+
+    it 'should render failure groups sorted in descending order' do
+      failure_group = create(:failure_group)
+      create(:failed_job, failure_group_id: failure_group.id)
+      login_as admin
+      get admin_failure_groups_path(order: 'job_count_desc')
+      assert_response :ok
+    end
+  end
+
   describe 'decategorize' do
     it 'should decategorize failure groups ' do
       failure_group = create(:failure_group)


### PR DESCRIPTION
Added functionality to provide sort option for job_count in failure groups admin page by tweaking ActiveAdmin's scoped_collection.

This tweak has been made since ActiveAdmin sort option for association count is not working as expected by the default sortable option.
