### PR TITLE
OTWO-3122 Reduced the people index page cache time from 1 day to 4 hours

### DIFF
--- a/app/helpers/people_helper.rb
+++ b/app/helpers/people_helper.rb
@@ -14,7 +14,7 @@ module PeopleHelper
 
   def render_people_list
     if params[:query].blank?
-      Rails.cache.fetch('people_index_page', expires_in: 1.day) do
+      Rails.cache.fetch('people_index_page', expires_in: 4.hours) do
         render 'people'
       end
     else


### PR DESCRIPTION
We cut the cache expiration time from 1 day to 4 hours in order to avoid commits count mismatch visual upon /people page for an entire day.
