### PR TITLE
Use the post method for the make_bot

### DIFF
--- a/app/views/accounts/show/_mark_as_bot.html.haml
+++ b/app/views/accounts/show/_mark_as_bot.html.haml
@@ -2,4 +2,4 @@
   = disabled_button t('.marked_as_bot'), title: t('.title', name: @account.name)
 - else
   = icon_button(make_bot_account_accesses_path(@account), text: t('.link'), size: 'small', type: 'info',
-      title: t('.title', name: @account.name), icon: 'check')
+      title: t('.title', name: @account.name), icon: 'check', method: :post)


### PR DESCRIPTION
The make_bot_account_accesses_path defaults to a GET method.
Hence added an option to the icon_button method call to set the method to post.
