### PR TITLE
Add warning message to new registration page

### DIFF
--- a/app/assets/stylesheets/accounts/new.sass
+++ b/app/assets/stylesheets/accounts/new.sass
@@ -2,5 +2,8 @@
   #welcome-message-container
     padding: 0px !important
 
-#welcome-message
-  margin-left: -16px
+.well .fa-exclamation-triangle
+  color: red
+
+.well .fa-smile-o
+  color: green

--- a/app/views/registrations/_join_now.html.haml
+++ b/app/views/registrations/_join_now.html.haml
@@ -5,3 +5,19 @@
     = t('.welcome_bullet_2')
   %li
     = t('.welcome_bullet_3')
+%hr
+%h4
+  %span.fa.fa-exclamation-triangle
+  = t('.please_note')
+%p
+  = t('.creating_account_html', terms: link_to(t('.terms_of_use'), 'https://blog.openhub.net/terms'))
+%ul
+  %li
+    = t('.note_bullet_1')
+  %li
+    = t('.note_bullet_2')
+  %li
+    = t('.note_bullet_3')
+%p
+  = t('.we_dont_like_disabling')
+  %span.fa.fa-smile-o

--- a/config/locales/registrations.en.yml
+++ b/config/locales/registrations.en.yml
@@ -7,9 +7,17 @@ en:
       invite_code_message: 'The first step to claim your Open Source contribution is create an Open Hub account.'
 
     join_now:
+      please_note: 'Please Note'
+      terms_of_use: 'Terms of Use'
+      creating_account_html: "By creating an account on the Open Hub you agree to comply with the %{terms}.  Please note these brief points:"
+      note_bullet_1: 'Accounts must be created for an individual.'
+      note_bullet_2: 'Accounts created to represent a company will be disabled.'
+      note_bullet_3: 'Accounts created for the purpose of advertising, link generation, marketing, or SEO, etc. will be disabled.'
+      we_dont_like_disabling: "We don\'t like disabling accounts any more than you would like to have your account disabled, but we like it even less when folks try to abuse this free service. Please help us keep the Open Hub a useful service to all. Thanks!"
       welcome_bullet_1: 'Claim all of your commits to projects across all of Open Hub, building a complete picture of your contributions to FOSS.'
       welcome_bullet_2: 'Manage projects.'
       welcome_bullet_3: 'Create project "stacks" that detail your usage of FOSS, and rate and review the projects you know.'
+
     welcome:
       title: 'Welcome to Open Hub!'
       description: 'You can use Open Hub without logging in, or having an account.  But with an account, you can do so much more:'

--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -1,11 +1,17 @@
 namespace :ci do
   desc 'Run the complete build verification'
   task :all_tasks do
+    puts '*** Running Rubocop'
     exit(1) unless system('rubocop')
+    puts '*** Running HAML-Lint'
     exit(1) unless system('haml-lint .')
+    puts '*** Running Brakeman'
     exit(1) unless system('brakeman -qz')
+    puts '*** Running Bundle Audit'
     exit(1) unless system('bundle exec bundle-audit update && bundle exec bundle-audit check')
+    puts '*** Running teaspoon'
     exit(1) unless system('RAILS_ENV=test teaspoon --no-color')
+    puts '*** Running Rake Test'
     exit(1) unless system('RAILS_ENV=test rake test')
     puts 'PASSED'
   end


### PR DESCRIPTION
We get a fair number of people who continue to created accounts that
violate the Terms Of Use.  Somewhere in the flow, we tell the user that
they have to comply with the TOU, but I can't remember the last time _I_
read one of those.

So, it seemed like a good idea to give our users some basic guidelines
