### PR TITLE
Restore support for 'q' as well as 'query'

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -218,6 +218,7 @@ class ApplicationController < ActionController::Base
   end
 
   def strip_query_param
+    params[:query] ||= params[:q]
     params[:query] = String.clean_string(params[:query])
   end
 

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -25,8 +25,26 @@ describe 'ProjectsController' do
     must_select "div.well#project_#{project3.id}", false
   end
 
+  it 'index should handle the q param for unlogged users' do
+    project1 = create(:project, name: 'Foo', description: Faker::Lorem.sentence(90))
+    project2 = create(:project, name: 'FooBar', description: Faker::Lorem.sentence(90))
+    project3 = create(:project, name: 'Goobaz', description: Faker::Lorem.sentence(90))
+    login_as nil
+    get :index, q: 'foo'
+    must_respond_with :ok
+    must_select "div.well#project_#{project1.id}", true
+    must_select "div.well#project_#{project2.id}", true
+    must_select "div.well#project_#{project3.id}", false
+  end
+
   it 'index should handle query param that matches no project' do
     get :index, query: 'qwertyuioplkjhgfdsazxcvbnm'
+    must_respond_with :ok
+    must_select 'div.advanced_search_tips', true
+  end
+
+  it 'index should handle q param that matches no project' do
+    get :index, q: 'qwertyuioplkjhgfdsazxcvbnm'
     must_respond_with :ok
     must_select 'div.advanced_search_tips', true
   end
@@ -40,11 +58,29 @@ describe 'ProjectsController' do
     response.body.must_match(/first.*second/m)
   end
 
+  it 'index should handle q param sorting by new' do
+    create(:project, name: 'Foo_new', description: 'second', created_at: Time.current - 3.hours)
+    create(:project, name: 'FooBar_new', description: 'first')
+    login_as nil
+    get :index, q: 'foo', sort: 'new'
+    must_respond_with :ok
+    response.body.must_match(/first.*second/m)
+  end
+
   it 'index should handle query param sorting by "activity_level"' do
     create(:project, name: 'Foo_activity_level', description: 'second', activity_level_index: 0)
     create(:project, name: 'FooBar_activity_level', description: 'first', activity_level_index: 20)
     login_as nil
     get :index, query: 'foo', sort: 'activity_level'
+    must_respond_with :ok
+    response.body.must_match(/first.*second/m)
+  end
+
+  it 'index should handle q param sorting by "activity_level"' do
+    create(:project, name: 'Foo_activity_level', description: 'second', activity_level_index: 0)
+    create(:project, name: 'FooBar_activity_level', description: 'first', activity_level_index: 20)
+    login_as nil
+    get :index, q: 'foo', sort: 'activity_level'
     must_respond_with :ok
     response.body.must_match(/first.*second/m)
   end
@@ -58,11 +94,29 @@ describe 'ProjectsController' do
     response.body.must_match(/first.*second/m)
   end
 
+  it 'index should handle q param sorting by "users"' do
+    create(:project, name: 'Foo_users', description: 'second', user_count: 1)
+    create(:project, name: 'FooBar_users', description: 'first', user_count: 20)
+    login_as nil
+    get :index, q: 'foo', sort: 'users'
+    must_respond_with :ok
+    response.body.must_match(/first.*second/m)
+  end
+
   it 'index should handle query param sorting by "rating"' do
     create(:project, name: 'Foo_rating', description: 'second', rating_average: 2)
     create(:project, name: 'FooBar_rating', description: 'first', rating_average: 4)
     login_as nil
     get :index, query: 'foo', sort: 'rating'
+    must_respond_with :ok
+    response.body.must_match(/first.*second/m)
+  end
+
+  it 'index should handle q param sorting by "rating"' do
+    create(:project, name: 'Foo_rating', description: 'second', rating_average: 2)
+    create(:project, name: 'FooBar_rating', description: 'first', rating_average: 4)
+    login_as nil
+    get :index, q: 'foo', sort: 'rating'
     must_respond_with :ok
     response.body.must_match(/first.*second/m)
   end
@@ -76,11 +130,32 @@ describe 'ProjectsController' do
     response.body.must_match(/first.*second/m)
   end
 
+  it 'index should handle q param sorting by "active_committers"' do
+    create(:project, name: 'Foo_active_committers', description: 'second', active_committers: 23)
+    create(:project, name: 'FooBar_active_committers', description: 'first', active_committers: 42)
+    login_as nil
+    get :index, q: 'foo', sort: 'active_committers'
+    must_respond_with :ok
+    response.body.must_match(/first.*second/m)
+  end
+
   it 'index should handle query param with atom format' do
     create(:project, name: 'Foo_atom', description: 'second', rating_average: 2)
     create(:project, name: 'FooBar_atom', description: 'first', rating_average: 4)
     login_as nil
     get :index, query: 'foo', sort: 'rating', format: 'atom'
+    must_respond_with :ok
+    nodes = Nokogiri::XML(response.body).css('entry')
+    nodes.length.must_equal 2
+    nodes[0].css('title').children.to_s.must_equal 'FooBar_atom'
+    nodes[1].css('title').children.to_s.must_equal 'Foo_atom'
+  end
+
+  it 'index should handle q param with atom format' do
+    create(:project, name: 'Foo_atom', description: 'second', rating_average: 2)
+    create(:project, name: 'FooBar_atom', description: 'first', rating_average: 4)
+    login_as nil
+    get :index, q: 'foo', sort: 'rating', format: 'atom'
     must_respond_with :ok
     nodes = Nokogiri::XML(response.body).css('entry')
     nodes.length.must_equal 2


### PR DESCRIPTION
Code Center has been invoking Open Hub URLS with the '?q=some_string'
format consistently, but we seem to have dropped support for that with
Project PURR. The issue was recently raised. And while the Code Center
team can make a fix and push that into the new version of Code Center,
it is much easier and faster for the Open Hub to honor the 'q' query
parameter form as it used to.

This change set is focused on testing this string for the Project
controller although the change is low-level and should be available
every place we currently use "query" as a query string paramater.
