### PR TITLE
OTWO-4278 Updated structure.sql with clumps table drop

### DIFF
--- a/db/structure.sql
+++ b/db/structure.sql
@@ -26,97 +26,6 @@ COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
 SET search_path = public, pg_catalog;
 
 --
--- Name: statinfo; Type: TYPE; Schema: public; Owner: -
---
-
-CREATE TYPE statinfo AS (
-	word text,
-	ndoc integer,
-	nentry integer
-);
-
-
---
--- Name: tokenout; Type: TYPE; Schema: public; Owner: -
---
-
-CREATE TYPE tokenout AS (
-	tokid integer,
-	token text
-);
-
-
---
--- Name: tokentype; Type: TYPE; Schema: public; Owner: -
---
-
-CREATE TYPE tokentype AS (
-	tokid integer,
-	alias text,
-	descr text
-);
-
-
---
--- Name: tsdebug; Type: TYPE; Schema: public; Owner: -
---
-
-CREATE TYPE tsdebug AS (
-	ts_name text,
-	tok_type text,
-	description text,
-	token text,
-	dict_name text[],
-	tsvector tsvector
-);
-
-
---
--- Name: _get_parser_from_curcfg(); Type: FUNCTION; Schema: public; Owner: -
---
-
-CREATE FUNCTION _get_parser_from_curcfg() RETURNS text
-    LANGUAGE sql IMMUTABLE STRICT
-    AS $$ select prs_name from pg_ts_cfg where oid = show_curcfg() $$;
-
-
---
--- Name: check_jobs(integer); Type: FUNCTION; Schema: public; Owner: -
---
-
-CREATE FUNCTION check_jobs(integer) RETURNS integer
-    LANGUAGE sql
-    AS $_$select repository_id as RESULT from jobs where status != 5 AND  repository_id= $1;$_$;
-
-
---
--- Name: ts_debug(text); Type: FUNCTION; Schema: public; Owner: -
---
-
-CREATE FUNCTION ts_debug(text) RETURNS SETOF tsdebug
-    LANGUAGE sql STRICT
-    AS $_$
-select 
-        m.ts_name,
-        t.alias as tok_type,
-        t.descr as description,
-        p.token,
-        m.dict_name,
-        strip(to_tsvector(p.token)) as tsvector
-from
-        parse( _get_parser_from_curcfg(), $1 ) as p,
-        token_type() as t,
-        pg_ts_cfgmap as m,
-        pg_ts_cfg as c
-where
-        t.tokid=p.tokid and
-        t.alias = m.tok_alias and 
-        m.ts_name=c.ts_name and 
-        c.oid=show_curcfg() 
-$_$;
-
-
---
 -- Name: default; Type: TEXT SEARCH CONFIGURATION; Schema: public; Owner: -
 --
 
@@ -181,71 +90,6 @@ ALTER TEXT SEARCH CONFIGURATION "default"
     ADD MAPPING FOR uint WITH simple;
 
 
---
--- Name: pg; Type: TEXT SEARCH CONFIGURATION; Schema: public; Owner: -
---
-
-CREATE TEXT SEARCH CONFIGURATION pg (
-    PARSER = pg_catalog."default" );
-
-ALTER TEXT SEARCH CONFIGURATION pg
-    ADD MAPPING FOR asciiword WITH english_stem;
-
-ALTER TEXT SEARCH CONFIGURATION pg
-    ADD MAPPING FOR word WITH english_stem;
-
-ALTER TEXT SEARCH CONFIGURATION pg
-    ADD MAPPING FOR numword WITH simple;
-
-ALTER TEXT SEARCH CONFIGURATION pg
-    ADD MAPPING FOR email WITH simple;
-
-ALTER TEXT SEARCH CONFIGURATION pg
-    ADD MAPPING FOR url WITH simple;
-
-ALTER TEXT SEARCH CONFIGURATION pg
-    ADD MAPPING FOR host WITH simple;
-
-ALTER TEXT SEARCH CONFIGURATION pg
-    ADD MAPPING FOR sfloat WITH simple;
-
-ALTER TEXT SEARCH CONFIGURATION pg
-    ADD MAPPING FOR version WITH simple;
-
-ALTER TEXT SEARCH CONFIGURATION pg
-    ADD MAPPING FOR hword_numpart WITH simple;
-
-ALTER TEXT SEARCH CONFIGURATION pg
-    ADD MAPPING FOR hword_part WITH english_stem;
-
-ALTER TEXT SEARCH CONFIGURATION pg
-    ADD MAPPING FOR hword_asciipart WITH english_stem;
-
-ALTER TEXT SEARCH CONFIGURATION pg
-    ADD MAPPING FOR numhword WITH simple;
-
-ALTER TEXT SEARCH CONFIGURATION pg
-    ADD MAPPING FOR asciihword WITH english_stem;
-
-ALTER TEXT SEARCH CONFIGURATION pg
-    ADD MAPPING FOR hword WITH english_stem;
-
-ALTER TEXT SEARCH CONFIGURATION pg
-    ADD MAPPING FOR url_path WITH simple;
-
-ALTER TEXT SEARCH CONFIGURATION pg
-    ADD MAPPING FOR file WITH simple;
-
-ALTER TEXT SEARCH CONFIGURATION pg
-    ADD MAPPING FOR "float" WITH simple;
-
-ALTER TEXT SEARCH CONFIGURATION pg
-    ADD MAPPING FOR "int" WITH simple;
-
-ALTER TEXT SEARCH CONFIGURATION pg
-    ADD MAPPING FOR uint WITH simple;
-
-
 SET default_tablespace = '';
 
 SET default_with_oids = false;
@@ -281,23 +125,11 @@ ALTER SEQUENCE account_reports_id_seq OWNED BY account_reports.id;
 
 
 --
--- Name: accounts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE accounts_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
 -- Name: accounts; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE accounts (
-    id integer DEFAULT nextval('accounts_id_seq'::regclass) NOT NULL,
+    id integer NOT NULL,
     login text NOT NULL,
     email text NOT NULL,
     crypted_password text NOT NULL,
@@ -340,6 +172,25 @@ CREATE TABLE accounts (
 
 
 --
+-- Name: accounts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE accounts_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: accounts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE accounts_id_seq OWNED BY accounts.id;
+
+
+--
 -- Name: actions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -374,18 +225,6 @@ ALTER SEQUENCE actions_id_seq OWNED BY actions.id;
 
 
 --
--- Name: activity_facts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE activity_facts_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
 -- Name: activity_facts; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -399,11 +238,30 @@ CREATE TABLE activity_facts (
     blanks_added integer DEFAULT 0,
     blanks_removed integer DEFAULT 0,
     name_id integer NOT NULL,
-    id bigint DEFAULT nextval('activity_facts_id_seq'::regclass) NOT NULL,
+    id bigint NOT NULL,
     analysis_id integer NOT NULL,
     commits integer DEFAULT 0,
     on_trunk boolean DEFAULT true
 );
+
+
+--
+-- Name: activity_facts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE activity_facts_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: activity_facts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE activity_facts_id_seq OWNED BY activity_facts.id;
 
 
 --
@@ -449,23 +307,11 @@ CREATE TABLE all_months (
 
 
 --
--- Name: analyses_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE analyses_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
 -- Name: analyses; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE analyses (
-    id integer DEFAULT nextval('analyses_id_seq'::regclass) NOT NULL,
+    id integer NOT NULL,
     project_id integer NOT NULL,
     as_of timestamp without time zone,
     updated_on timestamp without time zone,
@@ -486,6 +332,25 @@ CREATE TABLE analyses (
     activity_score integer,
     hotness_score double precision
 );
+
+
+--
+-- Name: analyses_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE analyses_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: analyses_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE analyses_id_seq OWNED BY analyses.id;
 
 
 --
@@ -520,6 +385,21 @@ ALTER SEQUENCE analysis_aliases_id_seq OWNED BY analysis_aliases.id;
 
 
 --
+-- Name: analysis_sloc_sets; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE analysis_sloc_sets (
+    id integer NOT NULL,
+    analysis_id integer NOT NULL,
+    sloc_set_id integer NOT NULL,
+    as_of integer,
+    logged_at timestamp without time zone,
+    ignore text,
+    ignored_fyle_count integer
+);
+
+
+--
 -- Name: analysis_sloc_sets_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
@@ -532,18 +412,10 @@ CREATE SEQUENCE analysis_sloc_sets_id_seq
 
 
 --
--- Name: analysis_sloc_sets; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: analysis_sloc_sets_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-CREATE TABLE analysis_sloc_sets (
-    id integer DEFAULT nextval('analysis_sloc_sets_id_seq'::regclass) NOT NULL,
-    analysis_id integer NOT NULL,
-    sloc_set_id integer NOT NULL,
-    as_of integer,
-    logged_at timestamp without time zone,
-    ignore text,
-    ignored_fyle_count integer
-);
+ALTER SEQUENCE analysis_sloc_sets_id_seq OWNED BY analysis_sloc_sets.id;
 
 
 --
@@ -608,8 +480,7 @@ CREATE TABLE api_keys (
     url text,
     support_url text,
     callback_url text,
-    secret text,
-    oauth_application_id integer
+    secret text
 );
 
 
@@ -707,35 +578,6 @@ ALTER SEQUENCE authorizations_id_seq OWNED BY authorizations.id;
 
 
 --
--- Name: commits_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE commits_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: commits; Type: TABLE; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE TABLE commits (
-    id integer DEFAULT nextval('commits_id_seq'::regclass) NOT NULL,
-    sha1 text,
-    "time" timestamp without time zone NOT NULL,
-    comment text,
-    code_set_id integer NOT NULL,
-    name_id integer NOT NULL,
-    "position" integer,
-    on_trunk boolean DEFAULT true,
-    email_address_id integer
-);
-
-
---
 -- Name: positions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -757,10 +599,10 @@ CREATE TABLE positions (
 
 
 --
--- Name: projects_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: claims_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE projects_id_seq
+CREATE SEQUENCE claims_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -769,92 +611,10 @@ CREATE SEQUENCE projects_id_seq
 
 
 --
--- Name: projects; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: claims_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-CREATE TABLE projects (
-    id integer DEFAULT nextval('projects_id_seq'::regclass) NOT NULL,
-    name text,
-    description text,
-    comments text,
-    best_analysis_id integer,
-    deleted boolean DEFAULT false NOT NULL,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL,
-    old_name text,
-    missing_source text,
-    logo_id integer,
-    vanity_url text,
-    downloadable boolean DEFAULT false,
-    scraped boolean DEFAULT false,
-    vector tsvector,
-    popularity_factor numeric,
-    user_count integer DEFAULT 0 NOT NULL,
-    rating_average real,
-    forge_id integer,
-    name_at_forge text,
-    owner_at_forge text,
-    active_committers integer DEFAULT 0,
-    kb_id integer,
-    organization_id integer,
-    activity_level_index integer,
-    uuid character varying,
-    CONSTRAINT valid_missing_source CHECK ((((missing_source IS NULL) OR (missing_source = 'not available'::text)) OR (missing_source = 'not supported'::text)))
-);
-
-
---
--- Name: sloc_sets_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE sloc_sets_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: sloc_sets; Type: TABLE; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE TABLE sloc_sets (
-    id integer DEFAULT nextval('sloc_sets_id_seq'::regclass) NOT NULL,
-    code_set_id integer NOT NULL,
-    updated_on timestamp without time zone,
-    as_of integer,
-    logged_at timestamp without time zone
-);
-
-
---
--- Name: c2; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW c2 AS
- SELECT commits.id,
-    commits.id AS commit_id,
-    analysis_sloc_sets.analysis_id,
-    projects.id AS project_id,
-    analysis_sloc_sets.sloc_set_id,
-    sloc_sets.code_set_id,
-    positions.id AS position_id,
-    positions.account_id,
-        CASE
-            WHEN (positions.account_id IS NULL) THEN ((((projects.id)::bigint << 32) + (commits.name_id)::bigint) + (B'10000000000000000000000000000000'::"bit")::bigint)
-            ELSE (((projects.id)::bigint << 32) + (positions.account_id)::bigint)
-        END AS contribution_id,
-        CASE
-            WHEN (positions.account_id IS NULL) THEN ((((projects.id)::bigint << 32) + (commits.name_id)::bigint) + (B'10000000000000000000000000000000'::"bit")::bigint)
-            ELSE (positions.account_id)::bigint
-        END AS person_id
-   FROM (((((analysis_sloc_sets
-     JOIN projects ON ((analysis_sloc_sets.analysis_id = projects.best_analysis_id)))
-     JOIN sloc_sets ON ((sloc_sets.id = analysis_sloc_sets.sloc_set_id)))
-     JOIN commits ON (((commits.code_set_id = sloc_sets.code_set_id) AND (commits."position" <= analysis_sloc_sets.as_of))))
-     JOIN analysis_aliases ON (((analysis_aliases.analysis_id = projects.best_analysis_id) AND (analysis_aliases.commit_name_id = commits.name_id))))
-     LEFT JOIN positions ON (((positions.project_id = projects.id) AND (positions.name_id = analysis_aliases.preferred_name_id))));
+ALTER SEQUENCE claims_id_seq OWNED BY positions.id;
 
 
 --
@@ -866,7 +626,7 @@ CREATE TABLE clumps (
     slave_id integer,
     code_set_id integer,
     updated_at timestamp without time zone,
-    type text NOT NULL,
+    type text,
     fetched_at timestamp without time zone
 );
 
@@ -888,6 +648,40 @@ CREATE SEQUENCE clumps_id_seq
 --
 
 ALTER SEQUENCE clumps_id_seq OWNED BY clumps.id;
+
+
+--
+-- Name: code_locations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE code_locations (
+    id integer NOT NULL,
+    repository_id integer,
+    module_branch_name text,
+    status integer DEFAULT 1,
+    best_code_set_id integer,
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone
+);
+
+
+--
+-- Name: code_locations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE code_locations_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: code_locations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE code_locations_id_seq OWNED BY code_locations.id;
 
 
 --
@@ -922,6 +716,23 @@ ALTER SEQUENCE code_set_gestalts_id_seq OWNED BY code_set_gestalts.id;
 
 
 --
+-- Name: code_sets; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE code_sets (
+    id integer NOT NULL,
+    repository_id integer,
+    updated_on timestamp without time zone,
+    best_sloc_set_id integer,
+    as_of integer,
+    logged_at timestamp without time zone,
+    clump_count integer DEFAULT 0,
+    fetched_at timestamp without time zone,
+    code_location_id integer
+);
+
+
+--
 -- Name: code_sets_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
@@ -934,19 +745,10 @@ CREATE SEQUENCE code_sets_id_seq
 
 
 --
--- Name: code_sets; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: code_sets_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-CREATE TABLE code_sets (
-    id integer DEFAULT nextval('code_sets_id_seq'::regclass) NOT NULL,
-    repository_id integer NOT NULL,
-    updated_on timestamp without time zone,
-    best_sloc_set_id integer,
-    as_of integer,
-    logged_at timestamp without time zone,
-    clump_count integer DEFAULT 0,
-    fetched_at timestamp without time zone
-);
+ALTER SEQUENCE code_sets_id_seq OWNED BY code_sets.id;
 
 
 --
@@ -983,10 +785,27 @@ ALTER SEQUENCE commit_flags_id_seq OWNED BY commit_flags.id;
 
 
 --
--- Name: name_facts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: commits; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
-CREATE SEQUENCE name_facts_id_seq
+CREATE TABLE commits (
+    id integer NOT NULL,
+    sha1 text,
+    "time" timestamp without time zone NOT NULL,
+    comment text,
+    code_set_id integer NOT NULL,
+    name_id integer NOT NULL,
+    "position" integer,
+    on_trunk boolean DEFAULT true,
+    email_address_id integer
+);
+
+
+--
+-- Name: commits_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE commits_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -995,11 +814,18 @@ CREATE SEQUENCE name_facts_id_seq
 
 
 --
+-- Name: commits_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE commits_id_seq OWNED BY commits.id;
+
+
+--
 -- Name: name_facts; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE name_facts (
-    id integer DEFAULT nextval('name_facts_id_seq'::regclass) NOT NULL,
+    id integer NOT NULL,
     analysis_id integer,
     name_id integer,
     primary_language_id integer,
@@ -1042,6 +868,40 @@ CREATE TABLE people (
 
 
 --
+-- Name: projects; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE projects (
+    id integer NOT NULL,
+    name text,
+    description text,
+    comments text,
+    best_analysis_id integer,
+    deleted boolean DEFAULT false NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
+    old_name text,
+    missing_source text,
+    logo_id integer,
+    vanity_url text,
+    downloadable boolean DEFAULT false,
+    vector tsvector,
+    popularity_factor numeric,
+    user_count integer DEFAULT 0 NOT NULL,
+    rating_average real,
+    forge_id integer,
+    name_at_forge text,
+    owner_at_forge text,
+    active_committers integer DEFAULT 0,
+    kb_id integer,
+    organization_id integer,
+    activity_level_index integer,
+    uuid character varying,
+    CONSTRAINT valid_missing_source CHECK ((((missing_source IS NULL) OR (missing_source = 'not available'::text)) OR (missing_source = 'not supported'::text)))
+);
+
+
+--
 -- Name: contributions; Type: VIEW; Schema: public; Owner: -
 --
 
@@ -1063,30 +923,6 @@ UNION
      JOIN positions ON ((positions.account_id = people.account_id)))
      LEFT JOIN projects ON ((projects.id = positions.project_id)))
      LEFT JOIN name_facts ON (((name_facts.analysis_id = projects.best_analysis_id) AND (name_facts.name_id = positions.name_id))));
-
-
---
--- Name: contributions2; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW contributions2 AS
- SELECT
-        CASE
-            WHEN (pos.id IS NULL) THEN ((((per.project_id)::bigint << 32) + (per.name_id)::bigint) + (B'10000000000000000000000000000000'::"bit")::bigint)
-            ELSE (((pos.project_id)::bigint << 32) + (pos.account_id)::bigint)
-        END AS id,
-        CASE
-            WHEN (pos.id IS NULL) THEN per.name_fact_id
-            ELSE ( SELECT name_facts.id
-               FROM name_facts
-              WHERE ((name_facts.analysis_id = p.best_analysis_id) AND (name_facts.name_id = pos.name_id)))
-        END AS name_fact_id,
-    pos.id AS position_id,
-    per.id AS person_id,
-    COALESCE(pos.project_id, per.project_id) AS project_id
-   FROM ((people per
-     LEFT JOIN positions pos ON ((per.account_id = pos.account_id)))
-     JOIN projects p ON ((p.id = COALESCE(pos.project_id, per.project_id))));
 
 
 --
@@ -1138,15 +974,19 @@ ALTER SEQUENCE deleted_accounts_id_seq OWNED BY deleted_accounts.id;
 
 
 --
--- Name: diff_licenses_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: diffs; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
-CREATE SEQUENCE diff_licenses_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
+CREATE TABLE diffs (
+    id bigint NOT NULL,
+    sha1 text,
+    parent_sha1 text,
+    commit_id integer,
+    fyle_id integer,
+    name text,
+    deleted boolean,
+    updated_at timestamp without time zone DEFAULT now() NOT NULL
+);
 
 
 --
@@ -1162,19 +1002,10 @@ CREATE SEQUENCE diffs_id_seq
 
 
 --
--- Name: diffs; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: diffs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-CREATE TABLE diffs (
-    id bigint DEFAULT nextval('diffs_id_seq'::regclass) NOT NULL,
-    sha1 text,
-    parent_sha1 text,
-    commit_id integer,
-    fyle_id integer,
-    name text,
-    deleted boolean,
-    updated_at timestamp without time zone DEFAULT now() NOT NULL
-);
+ALTER SEQUENCE diffs_id_seq OWNED BY diffs.id;
 
 
 --
@@ -1213,23 +1044,11 @@ ALTER SEQUENCE duplicates_id_seq OWNED BY duplicates.id;
 
 
 --
--- Name: edits_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE edits_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
 -- Name: edits; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE edits (
-    id integer DEFAULT nextval('edits_id_seq'::regclass) NOT NULL,
+    id integer NOT NULL,
     type text,
     target_id integer NOT NULL,
     target_type text NOT NULL,
@@ -1245,6 +1064,62 @@ CREATE TABLE edits (
     project_id integer,
     organization_id integer
 );
+
+
+--
+-- Name: old_edits; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE old_edits (
+    id integer NOT NULL,
+    project_id integer NOT NULL,
+    account_id integer NOT NULL,
+    created_at timestamp without time zone,
+    type text NOT NULL,
+    key text,
+    value text,
+    undone boolean DEFAULT false NOT NULL,
+    undone_at timestamp without time zone,
+    undone_by integer
+);
+
+
+--
+-- Name: edits_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE edits_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: edits_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE edits_id_seq OWNED BY old_edits.id;
+
+
+--
+-- Name: edits_id_seq1; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE edits_id_seq1
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: edits_id_seq1; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE edits_id_seq1 OWNED BY edits.id;
 
 
 --
@@ -1277,6 +1152,22 @@ ALTER SEQUENCE email_addresses_id_seq OWNED BY email_addresses.id;
 
 
 --
+-- Name: enlistments; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE enlistments (
+    id integer NOT NULL,
+    project_id integer NOT NULL,
+    repository_id integer,
+    deleted boolean DEFAULT false NOT NULL,
+    created_at timestamp without time zone DEFAULT timezone('UTC'::text, now()) NOT NULL,
+    updated_at timestamp without time zone DEFAULT timezone('UTC'::text, now()) NOT NULL,
+    ignore text,
+    code_location_id integer
+);
+
+
+--
 -- Name: enlistments_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
@@ -1289,52 +1180,10 @@ CREATE SEQUENCE enlistments_id_seq
 
 
 --
--- Name: enlistments; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: enlistments_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-CREATE TABLE enlistments (
-    id integer DEFAULT nextval('enlistments_id_seq'::regclass) NOT NULL,
-    project_id integer NOT NULL,
-    repository_id integer NOT NULL,
-    deleted boolean DEFAULT false NOT NULL,
-    created_at timestamp without time zone DEFAULT timezone('UTC'::text, now()) NOT NULL,
-    updated_at timestamp without time zone DEFAULT timezone('UTC'::text, now()) NOT NULL,
-    ignore text
-);
-
-
---
--- Name: event_subscription; Type: TABLE; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE TABLE event_subscription (
-    id integer NOT NULL,
-    subscriber_id integer,
-    klass text NOT NULL,
-    project_id integer,
-    topic_id integer,
-    account_id integer,
-    created_at timestamp without time zone NOT NULL
-);
-
-
---
--- Name: event_subscription_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE event_subscription_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: event_subscription_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE event_subscription_id_seq OWNED BY event_subscription.id;
+ALTER SEQUENCE enlistments_id_seq OWNED BY enlistments.id;
 
 
 --
@@ -1373,6 +1222,23 @@ ALTER SEQUENCE exhibits_id_seq OWNED BY exhibits.id;
 
 
 --
+-- Name: factoids; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE factoids (
+    id integer NOT NULL,
+    severity integer DEFAULT 0,
+    analysis_id integer NOT NULL,
+    type text,
+    license_id integer,
+    language_id integer,
+    previous_count integer DEFAULT 0,
+    current_count integer DEFAULT 0,
+    max_count integer DEFAULT 0
+);
+
+
+--
 -- Name: factoids_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
@@ -1385,20 +1251,10 @@ CREATE SEQUENCE factoids_id_seq
 
 
 --
--- Name: factoids; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: factoids_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-CREATE TABLE factoids (
-    id integer DEFAULT nextval('factoids_id_seq'::regclass) NOT NULL,
-    severity integer DEFAULT 0,
-    analysis_id integer NOT NULL,
-    type text,
-    license_id integer,
-    language_id integer,
-    previous_count integer DEFAULT 0,
-    current_count integer DEFAULT 0,
-    max_count integer DEFAULT 0
-);
+ALTER SEQUENCE factoids_id_seq OWNED BY factoids.id;
 
 
 --
@@ -1577,6 +1433,18 @@ ALTER SEQUENCE follows_id_seq OWNED BY follows.id;
 
 
 --
+-- Name: forges; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE forges (
+    id integer NOT NULL,
+    name text NOT NULL,
+    url text NOT NULL,
+    type text
+);
+
+
+--
 -- Name: forges_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
@@ -1589,14 +1457,24 @@ CREATE SEQUENCE forges_id_seq
 
 
 --
--- Name: forges; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: forges_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-CREATE TABLE forges (
-    id integer DEFAULT nextval('forges_id_seq'::regclass) NOT NULL,
+ALTER SEQUENCE forges_id_seq OWNED BY forges.id;
+
+
+--
+-- Name: forums; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE forums (
+    id integer NOT NULL,
+    project_id integer,
     name text NOT NULL,
-    url text NOT NULL,
-    type text
+    topics_count integer DEFAULT 0,
+    posts_count integer DEFAULT 0,
+    "position" integer,
+    description text
 );
 
 
@@ -1613,17 +1491,20 @@ CREATE SEQUENCE forums_id_seq
 
 
 --
--- Name: forums; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: forums_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-CREATE TABLE forums (
-    id integer DEFAULT nextval('forums_id_seq'::regclass) NOT NULL,
-    project_id integer,
+ALTER SEQUENCE forums_id_seq OWNED BY forums.id;
+
+
+--
+-- Name: fyles; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE fyles (
+    id integer NOT NULL,
     name text NOT NULL,
-    topics_count integer DEFAULT 0,
-    posts_count integer DEFAULT 0,
-    "position" integer,
-    description text
+    code_set_id integer NOT NULL
 );
 
 
@@ -1640,14 +1521,10 @@ CREATE SEQUENCE fyles_id_seq
 
 
 --
--- Name: fyles; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: fyles_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-CREATE TABLE fyles (
-    id integer DEFAULT nextval('fyles_id_seq'::regclass) NOT NULL,
-    name text NOT NULL,
-    code_set_id integer NOT NULL
-);
+ALTER SEQUENCE fyles_id_seq OWNED BY fyles.id;
 
 
 --
@@ -1713,27 +1590,14 @@ ALTER SEQUENCE gestalts_id_seq OWNED BY gestalts.id;
 
 
 --
--- Name: github_project; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: helpfuls; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
-CREATE TABLE github_project (
-    project_id text NOT NULL,
-    owner text NOT NULL,
-    state_code integer DEFAULT 660 NOT NULL,
-    description text,
-    homepage text,
-    has_downloads boolean,
-    is_fork boolean,
-    created timestamp without time zone DEFAULT now(),
-    updated timestamp without time zone DEFAULT now(),
-    last_spidered timestamp without time zone DEFAULT now(),
-    parent text,
-    source text,
-    watchers integer,
-    forks integer,
-    project_created timestamp without time zone,
-    note text,
-    organization text
+CREATE TABLE helpfuls (
+    id integer NOT NULL,
+    review_id integer,
+    account_id integer NOT NULL,
+    yes boolean DEFAULT true
 );
 
 
@@ -1750,15 +1614,10 @@ CREATE SEQUENCE helpfuls_id_seq
 
 
 --
--- Name: helpfuls; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: helpfuls_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-CREATE TABLE helpfuls (
-    id integer DEFAULT nextval('helpfuls_id_seq'::regclass) NOT NULL,
-    review_id integer,
-    account_id integer NOT NULL,
-    yes boolean DEFAULT true
-);
+ALTER SEQUENCE helpfuls_id_seq OWNED BY helpfuls.id;
 
 
 --
@@ -1809,23 +1668,11 @@ CREATE TABLE job_statuses (
 
 
 --
--- Name: jobs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE jobs_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
 -- Name: jobs; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE jobs (
-    id integer DEFAULT nextval('jobs_id_seq'::regclass) NOT NULL,
+    id integer NOT NULL,
     project_id integer,
     repository_id integer,
     status integer DEFAULT 0 NOT NULL,
@@ -1847,8 +1694,28 @@ CREATE TABLE jobs (
     retry_count integer DEFAULT 0,
     do_not_retry boolean DEFAULT false,
     failure_group_id integer,
-    organization_id integer
+    organization_id integer,
+    code_location_id integer
 );
+
+
+--
+-- Name: jobs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE jobs_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: jobs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE jobs_id_seq OWNED BY jobs.id;
 
 
 --
@@ -2056,23 +1923,11 @@ ALTER SEQUENCE language_facts_id_seq OWNED BY language_facts.id;
 
 
 --
--- Name: languages_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE languages_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
 -- Name: languages; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE languages (
-    id integer DEFAULT nextval('languages_id_seq'::regclass) NOT NULL,
+    id integer NOT NULL,
     name text,
     nice_name text,
     category integer DEFAULT 0,
@@ -2089,6 +1944,38 @@ CREATE TABLE languages (
 
 
 --
+-- Name: languages_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE languages_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: languages_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE languages_id_seq OWNED BY languages.id;
+
+
+--
+-- Name: license_facts; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE license_facts (
+    license_id integer NOT NULL,
+    file_count integer DEFAULT 0 NOT NULL,
+    scope integer DEFAULT 0 NOT NULL,
+    id integer NOT NULL,
+    analysis_id integer NOT NULL
+);
+
+
+--
 -- Name: license_facts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
@@ -2101,15 +1988,25 @@ CREATE SEQUENCE license_facts_id_seq
 
 
 --
--- Name: license_facts; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: license_facts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-CREATE TABLE license_facts (
-    license_id integer NOT NULL,
-    file_count integer DEFAULT 0 NOT NULL,
-    scope integer DEFAULT 0 NOT NULL,
-    id integer DEFAULT nextval('license_facts_id_seq'::regclass) NOT NULL,
-    analysis_id integer NOT NULL
+ALTER SEQUENCE license_facts_id_seq OWNED BY license_facts.id;
+
+
+--
+-- Name: licenses; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE licenses (
+    id integer NOT NULL,
+    vanity_url text,
+    name text,
+    abbreviation text,
+    url text,
+    description text,
+    deleted boolean DEFAULT false,
+    locked boolean DEFAULT false
 );
 
 
@@ -2126,19 +2023,10 @@ CREATE SEQUENCE licenses_id_seq
 
 
 --
--- Name: licenses; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: licenses_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-CREATE TABLE licenses (
-    id integer DEFAULT nextval('licenses_id_seq'::regclass) NOT NULL,
-    vanity_url text,
-    name text,
-    abbreviation text,
-    url text,
-    description text,
-    deleted boolean DEFAULT false,
-    locked boolean DEFAULT false
-);
+ALTER SEQUENCE licenses_id_seq OWNED BY licenses.id;
 
 
 --
@@ -2360,58 +2248,44 @@ ALTER SEQUENCE messages_id_seq OWNED BY messages.id;
 
 
 --
--- Name: mistaken_jobs; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: name_facts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE TABLE mistaken_jobs (
-    id integer,
-    project_id integer,
-    repository_id integer,
-    status integer,
+CREATE SEQUENCE name_facts_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: name_facts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE name_facts_id_seq OWNED BY name_facts.id;
+
+
+--
+-- Name: name_language_facts; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE name_language_facts (
+    id integer NOT NULL,
+    name_id integer,
+    analysis_id integer,
+    language_id integer,
+    total_months integer DEFAULT 0,
+    total_commits integer DEFAULT 0,
+    total_activity_lines integer DEFAULT 0,
+    vita_id integer,
     type text,
-    priority integer,
-    current_step integer,
-    current_step_at timestamp without time zone,
-    max_steps integer,
-    exception text,
-    backtrace text,
-    code_set_id integer,
-    sloc_set_id integer,
-    notes text,
-    wait_until timestamp without time zone,
-    account_id integer,
-    logged_at timestamp without time zone,
-    slave_id integer,
-    started_at timestamp without time zone,
-    retry_count integer,
-    do_not_retry boolean,
-    failure_group_id integer,
-    organization_id integer
+    comment_ratio numeric,
+    most_commits_project_id integer,
+    most_commits integer,
+    recent_commit_project_id integer,
+    recent_commit_month timestamp without time zone
 );
-
-
---
--- Name: moderatorships_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE moderatorships_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: monitorships_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE monitorships_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
 
 
 --
@@ -2427,24 +2301,22 @@ CREATE SEQUENCE name_language_facts_id_seq
 
 
 --
--- Name: name_language_facts; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: name_language_facts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-CREATE TABLE name_language_facts (
-    id integer DEFAULT nextval('name_language_facts_id_seq'::regclass) NOT NULL,
-    name_id integer,
-    analysis_id integer,
-    language_id integer,
-    total_months integer DEFAULT 0,
-    total_commits integer DEFAULT 0,
-    total_activity_lines integer DEFAULT 0,
-    vita_id integer,
-    type text,
-    comment_ratio numeric,
-    most_commits_project_id integer,
-    most_commits integer,
-    recent_commit_project_id integer,
-    recent_commit_month timestamp without time zone
+ALTER SEQUENCE name_language_facts_id_seq OWNED BY name_language_facts.id;
+
+
+--
+-- Name: sloc_sets; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE sloc_sets (
+    id integer NOT NULL,
+    code_set_id integer NOT NULL,
+    updated_on timestamp without time zone,
+    as_of integer,
+    logged_at timestamp without time zone
 );
 
 
@@ -2478,6 +2350,16 @@ CREATE VIEW named_commits AS
 
 
 --
+-- Name: names; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE names (
+    id integer NOT NULL,
+    name text NOT NULL
+);
+
+
+--
 -- Name: names_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
@@ -2490,120 +2372,10 @@ CREATE SEQUENCE names_id_seq
 
 
 --
--- Name: names; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: names_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-CREATE TABLE names (
-    id integer DEFAULT nextval('names_id_seq'::regclass) NOT NULL,
-    name text NOT NULL
-);
-
-
---
--- Name: oauth_access_grants; Type: TABLE; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE TABLE oauth_access_grants (
-    id integer NOT NULL,
-    resource_owner_id integer NOT NULL,
-    application_id integer NOT NULL,
-    token character varying NOT NULL,
-    expires_in integer NOT NULL,
-    redirect_uri text NOT NULL,
-    created_at timestamp without time zone NOT NULL,
-    revoked_at timestamp without time zone,
-    scopes character varying
-);
-
-
---
--- Name: oauth_access_grants_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE oauth_access_grants_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: oauth_access_grants_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE oauth_access_grants_id_seq OWNED BY oauth_access_grants.id;
-
-
---
--- Name: oauth_access_tokens; Type: TABLE; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE TABLE oauth_access_tokens (
-    id integer NOT NULL,
-    resource_owner_id integer,
-    application_id integer,
-    token character varying NOT NULL,
-    refresh_token character varying,
-    expires_in integer,
-    revoked_at timestamp without time zone,
-    created_at timestamp without time zone NOT NULL,
-    scopes character varying
-);
-
-
---
--- Name: oauth_access_tokens_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE oauth_access_tokens_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: oauth_access_tokens_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE oauth_access_tokens_id_seq OWNED BY oauth_access_tokens.id;
-
-
---
--- Name: oauth_applications; Type: TABLE; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE TABLE oauth_applications (
-    id integer NOT NULL,
-    name character varying NOT NULL,
-    uid character varying NOT NULL,
-    secret character varying NOT NULL,
-    redirect_uri text NOT NULL,
-    scopes character varying DEFAULT ''::character varying NOT NULL,
-    created_at timestamp without time zone,
-    updated_at timestamp without time zone
-);
-
-
---
--- Name: oauth_applications_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE oauth_applications_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: oauth_applications_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE oauth_applications_id_seq OWNED BY oauth_applications.id;
+ALTER SEQUENCE names_id_seq OWNED BY names.id;
 
 
 --
@@ -2636,36 +2408,6 @@ CREATE SEQUENCE oauth_nonces_id_seq
 --
 
 ALTER SEQUENCE oauth_nonces_id_seq OWNED BY oauth_nonces.id;
-
-
---
--- Name: old_edits_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE old_edits_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: old_edits; Type: TABLE; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE TABLE old_edits (
-    id integer DEFAULT nextval('old_edits_id_seq'::regclass) NOT NULL,
-    project_id integer NOT NULL,
-    account_id integer NOT NULL,
-    created_at timestamp without time zone,
-    type text NOT NULL,
-    key text,
-    value text,
-    undone boolean DEFAULT false NOT NULL,
-    undone_at timestamp without time zone,
-    undone_by integer
-);
 
 
 --
@@ -2782,18 +2524,6 @@ ALTER SEQUENCE organizations_id_seq OWNED BY organizations.id;
 
 
 --
--- Name: pages_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE pages_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
 -- Name: people_view; Type: VIEW; Schema: public; Owner: -
 --
 
@@ -2863,47 +2593,21 @@ CREATE SEQUENCE permissions_id_seq
 ALTER SEQUENCE permissions_id_seq OWNED BY permissions.id;
 
 
-SET default_with_oids = true;
-
 --
--- Name: pg_ts_cfg; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: posts; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
-CREATE TABLE pg_ts_cfg (
-    ts_name text NOT NULL,
-    prs_name text NOT NULL,
-    locale text
+CREATE TABLE posts (
+    id integer NOT NULL,
+    account_id integer NOT NULL,
+    topic_id integer NOT NULL,
+    body text,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone,
+    notified_at timestamp without time zone,
+    vector tsvector,
+    popularity_factor numeric
 );
-
-
---
--- Name: pg_ts_cfgmap; Type: TABLE; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE TABLE pg_ts_cfgmap (
-    ts_name text NOT NULL,
-    tok_alias text NOT NULL,
-    dict_name text[]
-);
-
-
---
--- Name: positions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE positions_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: positions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE positions_id_seq OWNED BY positions.id;
 
 
 --
@@ -2918,23 +2622,11 @@ CREATE SEQUENCE posts_id_seq
     CACHE 1;
 
 
-SET default_with_oids = false;
-
 --
--- Name: posts; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: posts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-CREATE TABLE posts (
-    id integer DEFAULT nextval('posts_id_seq'::regclass) NOT NULL,
-    account_id integer NOT NULL,
-    topic_id integer NOT NULL,
-    body text,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone,
-    notified_at timestamp without time zone,
-    vector tsvector,
-    popularity_factor numeric
-);
+ALTER SEQUENCE posts_id_seq OWNED BY posts.id;
 
 
 --
@@ -2968,20 +2660,6 @@ CREATE SEQUENCE profiles_id_seq
 --
 
 ALTER SEQUENCE profiles_id_seq OWNED BY profiles.id;
-
-
---
--- Name: project_counts_by_quarter_and_language; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW project_counts_by_quarter_and_language AS
- SELECT af.language_id,
-    date_trunc('quarter'::text, timezone('utc'::text, (af.month)::timestamp with time zone)) AS quarter,
-    count(DISTINCT af.analysis_id) AS project_count
-   FROM ((activity_facts af
-     JOIN analyses a ON ((a.id = af.analysis_id)))
-     JOIN projects p ON (((p.best_analysis_id = a.id) AND (NOT p.deleted))))
-  GROUP BY af.language_id, date_trunc('quarter'::text, timezone('utc'::text, (af.month)::timestamp with time zone));
 
 
 --
@@ -3050,29 +2728,14 @@ ALTER SEQUENCE project_experiences_id_seq OWNED BY project_experiences.id;
 
 
 --
--- Name: project_gestalt_view; Type: VIEW; Schema: public; Owner: -
+-- Name: project_licenses; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
-CREATE VIEW project_gestalt_view AS
- SELECT p.id AS project_id,
-    p.vanity_url AS url_name,
-    g.id AS gestalt_id,
-    g.name,
-    g.type
-   FROM ((projects p
-     JOIN project_gestalts pg ON ((p.id = pg.project_id)))
-     JOIN gestalts g ON ((g.id = pg.gestalt_id)));
-
-
---
--- Name: project_gestalts_tmp; Type: TABLE; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE TABLE project_gestalts_tmp (
-    id integer,
-    date timestamp without time zone,
+CREATE TABLE project_licenses (
+    id integer NOT NULL,
     project_id integer,
-    gestalt_id integer
+    license_id integer,
+    deleted boolean DEFAULT false
 );
 
 
@@ -3089,15 +2752,10 @@ CREATE SEQUENCE project_licenses_id_seq
 
 
 --
--- Name: project_licenses; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: project_licenses_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-CREATE TABLE project_licenses (
-    id integer DEFAULT nextval('project_licenses_id_seq'::regclass) NOT NULL,
-    project_id integer,
-    license_id integer,
-    deleted boolean DEFAULT false
-);
+ALTER SEQUENCE project_licenses_id_seq OWNED BY project_licenses.id;
 
 
 --
@@ -3165,16 +2823,36 @@ ALTER SEQUENCE project_vulnerability_reports_id_seq OWNED BY project_vulnerabili
 
 
 --
--- Name: projects_by_month; Type: VIEW; Schema: public; Owner: -
+-- Name: projects_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE VIEW projects_by_month AS
- SELECT m.month,
-    ( SELECT count(*) AS count
-           FROM (projects p
-             JOIN analyses a ON (((p.best_analysis_id = a.id) AND (NOT p.deleted))))
-          WHERE (date_trunc('quarter'::text, (a.min_month)::timestamp with time zone) <= date_trunc('quarter'::text, m.month))) AS project_count
-   FROM all_months m;
+CREATE SEQUENCE projects_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: projects_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE projects_id_seq OWNED BY projects.id;
+
+
+--
+-- Name: ratings; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE ratings (
+    id integer NOT NULL,
+    account_id integer NOT NULL,
+    project_id integer NOT NULL,
+    score integer NOT NULL,
+    created_at timestamp without time zone DEFAULT timezone('UTC'::text, now()),
+    updated_at timestamp without time zone DEFAULT timezone('UTC'::text, now())
+);
 
 
 --
@@ -3190,17 +2868,10 @@ CREATE SEQUENCE ratings_id_seq
 
 
 --
--- Name: ratings; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: ratings_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-CREATE TABLE ratings (
-    id integer DEFAULT nextval('ratings_id_seq'::regclass) NOT NULL,
-    account_id integer NOT NULL,
-    project_id integer NOT NULL,
-    score integer NOT NULL,
-    created_at timestamp without time zone DEFAULT timezone('UTC'::text, now()),
-    updated_at timestamp without time zone DEFAULT timezone('UTC'::text, now())
-);
+ALTER SEQUENCE ratings_id_seq OWNED BY ratings.id;
 
 
 --
@@ -3333,23 +3004,11 @@ ALTER SEQUENCE reports_id_seq OWNED BY reports.id;
 
 
 --
--- Name: repositories_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE repositories_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
 -- Name: repositories; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE repositories (
-    id integer DEFAULT nextval('repositories_id_seq'::regclass) NOT NULL,
+    id integer NOT NULL,
     url text,
     module_name text,
     branch_name text,
@@ -3364,6 +3023,25 @@ CREATE TABLE repositories (
     name_at_forge text,
     owner_at_forge text
 );
+
+
+--
+-- Name: repositories_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE repositories_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: repositories_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE repositories_id_seq OWNED BY repositories.id;
 
 
 --
@@ -3435,6 +3113,22 @@ ALTER SEQUENCE reverification_trackers_id_seq OWNED BY reverification_trackers.i
 
 
 --
+-- Name: reviews; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE reviews (
+    id integer NOT NULL,
+    account_id integer NOT NULL,
+    project_id integer NOT NULL,
+    title text,
+    comment text,
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone,
+    helpful_score integer DEFAULT 0 NOT NULL
+);
+
+
+--
 -- Name: reviews_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
@@ -3447,43 +3141,26 @@ CREATE SEQUENCE reviews_id_seq
 
 
 --
--- Name: reviews; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: reviews_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-CREATE TABLE reviews (
-    id integer DEFAULT nextval('reviews_id_seq'::regclass) NOT NULL,
-    account_id integer NOT NULL,
-    project_id integer NOT NULL,
-    title text,
-    comment text,
-    created_at timestamp without time zone,
-    updated_at timestamp without time zone,
-    helpful_score integer DEFAULT 0 NOT NULL
+ALTER SEQUENCE reviews_id_seq OWNED BY reviews.id;
+
+
+--
+-- Name: rss_articles; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE rss_articles (
+    id integer NOT NULL,
+    rss_feed_id integer,
+    guid text NOT NULL,
+    "time" timestamp without time zone DEFAULT timezone('utc'::text, now()) NOT NULL,
+    title text NOT NULL,
+    description text,
+    author text,
+    link text
 );
-
-
---
--- Name: robins_contributions_test; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW robins_contributions_test AS
- SELECT
-        CASE
-            WHEN (pos.id IS NULL) THEN ((((per.project_id)::bigint << 32) + (per.name_id)::bigint) + (B'10000000000000000000000000000000'::"bit")::bigint)
-            ELSE (((pos.project_id)::bigint << 32) + (pos.account_id)::bigint)
-        END AS id,
-    per.id AS person_id,
-    COALESCE(pos.project_id, per.project_id) AS project_id,
-        CASE
-            WHEN (pos.id IS NULL) THEN per.name_fact_id
-            ELSE ( SELECT name_facts.id
-               FROM name_facts
-              WHERE ((name_facts.analysis_id = p.best_analysis_id) AND (name_facts.name_id = pos.name_id)))
-        END AS name_fact_id,
-    pos.id AS position_id
-   FROM ((people per
-     LEFT JOIN positions pos ON ((per.account_id = pos.account_id)))
-     JOIN projects p ON ((p.id = COALESCE(pos.project_id, per.project_id))));
 
 
 --
@@ -3499,34 +3176,22 @@ CREATE SEQUENCE rss_articles_id_seq
 
 
 --
--- Name: rss_articles; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: rss_articles_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-CREATE TABLE rss_articles (
-    id integer DEFAULT nextval('rss_articles_id_seq'::regclass) NOT NULL,
-    rss_feed_id integer,
-    guid text NOT NULL,
-    "time" timestamp without time zone DEFAULT timezone('utc'::text, now()) NOT NULL,
-    title text NOT NULL,
-    description text,
-    author text,
-    link text
-);
+ALTER SEQUENCE rss_articles_id_seq OWNED BY rss_articles.id;
 
 
 --
--- Name: rss_articles_2; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: rss_feeds; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
-CREATE TABLE rss_articles_2 (
-    id integer,
-    rss_feed_id integer,
-    guid text,
-    "time" timestamp without time zone,
-    title text,
-    description text,
-    author text,
-    link text
+CREATE TABLE rss_feeds (
+    id integer NOT NULL,
+    url text NOT NULL,
+    last_fetch timestamp without time zone,
+    next_fetch timestamp without time zone,
+    error text
 );
 
 
@@ -3543,15 +3208,21 @@ CREATE SEQUENCE rss_feeds_id_seq
 
 
 --
--- Name: rss_feeds; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: rss_feeds_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-CREATE TABLE rss_feeds (
-    id integer DEFAULT nextval('rss_feeds_id_seq'::regclass) NOT NULL,
-    url text NOT NULL,
-    last_fetch timestamp without time zone,
-    next_fetch timestamp without time zone,
-    error text
+ALTER SEQUENCE rss_feeds_id_seq OWNED BY rss_feeds.id;
+
+
+--
+-- Name: rss_subscriptions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE rss_subscriptions (
+    id integer NOT NULL,
+    project_id integer,
+    rss_feed_id integer,
+    deleted boolean DEFAULT false
 );
 
 
@@ -3568,15 +3239,10 @@ CREATE SEQUENCE rss_subscriptions_id_seq
 
 
 --
--- Name: rss_subscriptions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: rss_subscriptions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-CREATE TABLE rss_subscriptions (
-    id integer DEFAULT nextval('rss_subscriptions_id_seq'::regclass) NOT NULL,
-    project_id integer,
-    rss_feed_id integer,
-    deleted boolean DEFAULT false
-);
+ALTER SEQUENCE rss_subscriptions_id_seq OWNED BY rss_subscriptions.id;
 
 
 --
@@ -3585,6 +3251,18 @@ CREATE TABLE rss_subscriptions (
 
 CREATE TABLE schema_migrations (
     version character varying(255) NOT NULL
+);
+
+
+--
+-- Name: sessions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE sessions (
+    id integer NOT NULL,
+    session_id character varying(255),
+    data text,
+    updated_at timestamp without time zone
 );
 
 
@@ -3601,82 +3279,25 @@ CREATE SEQUENCE sessions_id_seq
 
 
 --
--- Name: sessions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: sessions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-CREATE TABLE sessions (
-    id integer DEFAULT nextval('sessions_id_seq'::regclass) NOT NULL,
-    session_id character varying(255),
-    data text,
-    updated_at timestamp without time zone
-);
+ALTER SEQUENCE sessions_id_seq OWNED BY sessions.id;
 
 
 --
--- Name: settings; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: slave_logs; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
-CREATE TABLE settings (
+CREATE TABLE slave_logs (
     id integer NOT NULL,
-    key character varying,
-    value character varying,
-    created_at timestamp without time zone,
-    updated_at timestamp without time zone
+    message text,
+    created_on timestamp without time zone,
+    slave_id integer,
+    job_id integer,
+    code_set_id integer,
+    level integer DEFAULT 0
 );
-
-
---
--- Name: settings_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE settings_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: settings_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE settings_id_seq OWNED BY settings.id;
-
-
---
--- Name: sf_vhosted; Type: TABLE; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE TABLE sf_vhosted (
-    domain text NOT NULL
-);
-
-
---
--- Name: sfprojects; Type: TABLE; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE TABLE sfprojects (
-    project_id integer NOT NULL,
-    hosted boolean DEFAULT false,
-    vhosted boolean DEFAULT false,
-    code boolean DEFAULT false,
-    downloads boolean DEFAULT false,
-    downloads_vhosted boolean DEFAULT false
-);
-
-
---
--- Name: size_facts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE size_facts_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
 
 
 --
@@ -3692,30 +3313,10 @@ CREATE SEQUENCE slave_logs_id_seq
 
 
 --
--- Name: slave_logs; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: slave_logs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-CREATE TABLE slave_logs (
-    id integer DEFAULT nextval('slave_logs_id_seq'::regclass) NOT NULL,
-    message text,
-    created_on timestamp without time zone,
-    slave_id integer,
-    job_id integer,
-    code_set_id integer,
-    level integer DEFAULT 0
-);
-
-
---
--- Name: slave_permissions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE slave_permissions_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
+ALTER SEQUENCE slave_logs_id_seq OWNED BY slave_logs.id;
 
 
 --
@@ -3723,7 +3324,7 @@ CREATE SEQUENCE slave_permissions_id_seq
 --
 
 CREATE TABLE slaves (
-    id integer DEFAULT nextval('slave_permissions_id_seq'::regclass) NOT NULL,
+    id integer NOT NULL,
     allow_deny text,
     hostname text NOT NULL,
     available_blocks integer,
@@ -3740,6 +3341,43 @@ CREATE TABLE slaves (
 
 
 --
+-- Name: slave_permissions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE slave_permissions_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: slave_permissions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE slave_permissions_id_seq OWNED BY slaves.id;
+
+
+--
+-- Name: sloc_metrics; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE sloc_metrics (
+    id bigint NOT NULL,
+    diff_id bigint,
+    language_id integer,
+    code_added integer DEFAULT 0 NOT NULL,
+    code_removed integer DEFAULT 0 NOT NULL,
+    comments_added integer DEFAULT 0 NOT NULL,
+    comments_removed integer DEFAULT 0 NOT NULL,
+    blanks_added integer DEFAULT 0 NOT NULL,
+    blanks_removed integer DEFAULT 0 NOT NULL,
+    sloc_set_id integer NOT NULL
+);
+
+
+--
 -- Name: sloc_metrics_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
@@ -3752,20 +3390,42 @@ CREATE SEQUENCE sloc_metrics_id_seq
 
 
 --
--- Name: sloc_metrics; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: sloc_metrics_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-CREATE TABLE sloc_metrics (
-    id bigint DEFAULT nextval('sloc_metrics_id_seq'::regclass) NOT NULL,
-    diff_id bigint,
-    language_id integer,
-    code_added integer DEFAULT 0 NOT NULL,
-    code_removed integer DEFAULT 0 NOT NULL,
-    comments_added integer DEFAULT 0 NOT NULL,
-    comments_removed integer DEFAULT 0 NOT NULL,
-    blanks_added integer DEFAULT 0 NOT NULL,
-    blanks_removed integer DEFAULT 0 NOT NULL,
-    sloc_set_id integer NOT NULL
+ALTER SEQUENCE sloc_metrics_id_seq OWNED BY sloc_metrics.id;
+
+
+--
+-- Name: sloc_sets_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE sloc_sets_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: sloc_sets_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE sloc_sets_id_seq OWNED BY sloc_sets.id;
+
+
+--
+-- Name: stack_entries; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE stack_entries (
+    id integer NOT NULL,
+    stack_id integer,
+    project_id integer,
+    created_at timestamp without time zone NOT NULL,
+    deleted_at timestamp without time zone,
+    note text
 );
 
 
@@ -3782,17 +3442,10 @@ CREATE SEQUENCE stack_entries_id_seq
 
 
 --
--- Name: stack_entries; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: stack_entries_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-CREATE TABLE stack_entries (
-    id integer DEFAULT nextval('stack_entries_id_seq'::regclass) NOT NULL,
-    stack_id integer,
-    project_id integer,
-    created_at timestamp without time zone NOT NULL,
-    deleted_at timestamp without time zone,
-    note text
-);
+ALTER SEQUENCE stack_entries_id_seq OWNED BY stack_entries.id;
 
 
 --
@@ -3827,6 +3480,23 @@ ALTER SEQUENCE stack_ignores_id_seq OWNED BY stack_ignores.id;
 
 
 --
+-- Name: stacks; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE stacks (
+    id integer NOT NULL,
+    account_id integer,
+    session_id character varying(255),
+    project_count integer DEFAULT 0,
+    updated_at timestamp without time zone,
+    title text,
+    description text,
+    project_id integer,
+    deleted_at timestamp without time zone
+);
+
+
+--
 -- Name: stacks_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
@@ -3839,19 +3509,21 @@ CREATE SEQUENCE stacks_id_seq
 
 
 --
--- Name: stacks; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: stacks_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-CREATE TABLE stacks (
-    id integer DEFAULT nextval('stacks_id_seq'::regclass) NOT NULL,
-    account_id integer,
-    session_id character varying(255),
-    project_count integer DEFAULT 0,
-    updated_at timestamp without time zone,
-    title text,
-    description text,
-    project_id integer,
-    deleted_at timestamp without time zone
+ALTER SEQUENCE stacks_id_seq OWNED BY stacks.id;
+
+
+--
+-- Name: taggings; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE taggings (
+    id integer NOT NULL,
+    tag_id integer,
+    taggable_id integer,
+    taggable_type character varying(255)
 );
 
 
@@ -3868,14 +3540,21 @@ CREATE SEQUENCE taggings_id_seq
 
 
 --
--- Name: taggings; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: taggings_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-CREATE TABLE taggings (
-    id integer DEFAULT nextval('taggings_id_seq'::regclass) NOT NULL,
-    tag_id integer,
-    taggable_id integer,
-    taggable_type character varying(255)
+ALTER SEQUENCE taggings_id_seq OWNED BY taggings.id;
+
+
+--
+-- Name: tags; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE tags (
+    id integer NOT NULL,
+    name text NOT NULL,
+    taggings_count integer DEFAULT 0 NOT NULL,
+    weight double precision DEFAULT 1.0 NOT NULL
 );
 
 
@@ -3892,15 +3571,10 @@ CREATE SEQUENCE tags_id_seq
 
 
 --
--- Name: tags; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: tags_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-CREATE TABLE tags (
-    id integer DEFAULT nextval('tags_id_seq'::regclass) NOT NULL,
-    name text NOT NULL,
-    taggings_count integer DEFAULT 0 NOT NULL,
-    weight double precision DEFAULT 1.0 NOT NULL
-);
+ALTER SEQUENCE tags_id_seq OWNED BY tags.id;
 
 
 --
@@ -3969,6 +3643,28 @@ ALTER SEQUENCE tools_id_seq OWNED BY tools.id;
 
 
 --
+-- Name: topics; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE topics (
+    id integer NOT NULL,
+    forum_id integer,
+    account_id integer NOT NULL,
+    title text,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone,
+    hits integer DEFAULT 0,
+    sticky integer DEFAULT 0,
+    posts_count integer DEFAULT 0,
+    replied_at timestamp without time zone,
+    closed boolean DEFAULT false,
+    replied_by integer,
+    last_post_id integer,
+    page_id integer
+);
+
+
+--
 -- Name: topics_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
@@ -3981,24 +3677,10 @@ CREATE SEQUENCE topics_id_seq
 
 
 --
--- Name: topics; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: topics_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-CREATE TABLE topics (
-    id integer DEFAULT nextval('topics_id_seq'::regclass) NOT NULL,
-    forum_id integer,
-    account_id integer NOT NULL,
-    title text,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone,
-    hits integer DEFAULT 0,
-    sticky integer DEFAULT 0,
-    posts_count integer DEFAULT 0,
-    replied_at timestamp without time zone,
-    closed boolean DEFAULT false,
-    replied_by integer,
-    last_post_id integer
-);
+ALTER SEQUENCE topics_id_seq OWNED BY topics.id;
 
 
 --
@@ -4095,10 +3777,28 @@ ALTER SEQUENCE vitae_id_seq OWNED BY vitae.id;
 
 
 --
+-- Name: vw_projecturlnameedits; Type: VIEW; Schema: public; Owner: -
+--
+
+CREATE VIEW vw_projecturlnameedits AS
+ SELECT edits.project_id,
+    edits.value
+   FROM edits
+  WHERE ((edits.target_type = 'Project'::text) AND (edits.key = 'url_name'::text));
+
+
+--
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY account_reports ALTER COLUMN id SET DEFAULT nextval('account_reports_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY accounts ALTER COLUMN id SET DEFAULT nextval('accounts_id_seq'::regclass);
 
 
 --
@@ -4112,6 +3812,13 @@ ALTER TABLE ONLY actions ALTER COLUMN id SET DEFAULT nextval('actions_id_seq'::r
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
+ALTER TABLE ONLY activity_facts ALTER COLUMN id SET DEFAULT nextval('activity_facts_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY aliases ALTER COLUMN id SET DEFAULT nextval('aliases_id_seq'::regclass);
 
 
@@ -4119,7 +3826,21 @@ ALTER TABLE ONLY aliases ALTER COLUMN id SET DEFAULT nextval('aliases_id_seq'::r
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
+ALTER TABLE ONLY analyses ALTER COLUMN id SET DEFAULT nextval('analyses_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY analysis_aliases ALTER COLUMN id SET DEFAULT nextval('analysis_aliases_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY analysis_sloc_sets ALTER COLUMN id SET DEFAULT nextval('analysis_sloc_sets_id_seq'::regclass);
 
 
 --
@@ -4161,7 +3882,21 @@ ALTER TABLE ONLY clumps ALTER COLUMN id SET DEFAULT nextval('clumps_id_seq'::reg
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
+ALTER TABLE ONLY code_locations ALTER COLUMN id SET DEFAULT nextval('code_locations_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY code_set_gestalts ALTER COLUMN id SET DEFAULT nextval('code_set_gestalts_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY code_sets ALTER COLUMN id SET DEFAULT nextval('code_sets_id_seq'::regclass);
 
 
 --
@@ -4175,7 +3910,21 @@ ALTER TABLE ONLY commit_flags ALTER COLUMN id SET DEFAULT nextval('commit_flags_
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
+ALTER TABLE ONLY commits ALTER COLUMN id SET DEFAULT nextval('commits_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY deleted_accounts ALTER COLUMN id SET DEFAULT nextval('deleted_accounts_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY diffs ALTER COLUMN id SET DEFAULT nextval('diffs_id_seq'::regclass);
 
 
 --
@@ -4189,6 +3938,13 @@ ALTER TABLE ONLY duplicates ALTER COLUMN id SET DEFAULT nextval('duplicates_id_s
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
+ALTER TABLE ONLY edits ALTER COLUMN id SET DEFAULT nextval('edits_id_seq1'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY email_addresses ALTER COLUMN id SET DEFAULT nextval('email_addresses_id_seq'::regclass);
 
 
@@ -4196,7 +3952,7 @@ ALTER TABLE ONLY email_addresses ALTER COLUMN id SET DEFAULT nextval('email_addr
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY event_subscription ALTER COLUMN id SET DEFAULT nextval('event_subscription_id_seq'::regclass);
+ALTER TABLE ONLY enlistments ALTER COLUMN id SET DEFAULT nextval('enlistments_id_seq'::regclass);
 
 
 --
@@ -4204,6 +3960,13 @@ ALTER TABLE ONLY event_subscription ALTER COLUMN id SET DEFAULT nextval('event_s
 --
 
 ALTER TABLE ONLY exhibits ALTER COLUMN id SET DEFAULT nextval('exhibits_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY factoids ALTER COLUMN id SET DEFAULT nextval('factoids_id_seq'::regclass);
 
 
 --
@@ -4231,6 +3994,27 @@ ALTER TABLE ONLY follows ALTER COLUMN id SET DEFAULT nextval('follows_id_seq'::r
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
+ALTER TABLE ONLY forges ALTER COLUMN id SET DEFAULT nextval('forges_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY forums ALTER COLUMN id SET DEFAULT nextval('forums_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY fyles ALTER COLUMN id SET DEFAULT nextval('fyles_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY gestalts ALTER COLUMN id SET DEFAULT nextval('gestalts_id_seq'::regclass);
 
 
@@ -4238,7 +4022,21 @@ ALTER TABLE ONLY gestalts ALTER COLUMN id SET DEFAULT nextval('gestalts_id_seq':
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
+ALTER TABLE ONLY helpfuls ALTER COLUMN id SET DEFAULT nextval('helpfuls_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY invites ALTER COLUMN id SET DEFAULT nextval('invites_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY jobs ALTER COLUMN id SET DEFAULT nextval('jobs_id_seq'::regclass);
 
 
 --
@@ -4281,6 +4079,27 @@ ALTER TABLE ONLY language_experiences ALTER COLUMN id SET DEFAULT nextval('langu
 --
 
 ALTER TABLE ONLY language_facts ALTER COLUMN id SET DEFAULT nextval('language_facts_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY languages ALTER COLUMN id SET DEFAULT nextval('languages_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY license_facts ALTER COLUMN id SET DEFAULT nextval('license_facts_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY licenses ALTER COLUMN id SET DEFAULT nextval('licenses_id_seq'::regclass);
 
 
 --
@@ -4343,21 +4162,21 @@ ALTER TABLE ONLY messages ALTER COLUMN id SET DEFAULT nextval('messages_id_seq':
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY oauth_access_grants ALTER COLUMN id SET DEFAULT nextval('oauth_access_grants_id_seq'::regclass);
+ALTER TABLE ONLY name_facts ALTER COLUMN id SET DEFAULT nextval('name_facts_id_seq'::regclass);
 
 
 --
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY oauth_access_tokens ALTER COLUMN id SET DEFAULT nextval('oauth_access_tokens_id_seq'::regclass);
+ALTER TABLE ONLY name_language_facts ALTER COLUMN id SET DEFAULT nextval('name_language_facts_id_seq'::regclass);
 
 
 --
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY oauth_applications ALTER COLUMN id SET DEFAULT nextval('oauth_applications_id_seq'::regclass);
+ALTER TABLE ONLY names ALTER COLUMN id SET DEFAULT nextval('names_id_seq'::regclass);
 
 
 --
@@ -4365,6 +4184,13 @@ ALTER TABLE ONLY oauth_applications ALTER COLUMN id SET DEFAULT nextval('oauth_a
 --
 
 ALTER TABLE ONLY oauth_nonces ALTER COLUMN id SET DEFAULT nextval('oauth_nonces_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY old_edits ALTER COLUMN id SET DEFAULT nextval('edits_id_seq'::regclass);
 
 
 --
@@ -4399,7 +4225,14 @@ ALTER TABLE ONLY permissions ALTER COLUMN id SET DEFAULT nextval('permissions_id
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY positions ALTER COLUMN id SET DEFAULT nextval('positions_id_seq'::regclass);
+ALTER TABLE ONLY positions ALTER COLUMN id SET DEFAULT nextval('claims_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY posts ALTER COLUMN id SET DEFAULT nextval('posts_id_seq'::regclass);
 
 
 --
@@ -4434,6 +4267,13 @@ ALTER TABLE ONLY project_gestalts ALTER COLUMN id SET DEFAULT nextval('gestaltin
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
+ALTER TABLE ONLY project_licenses ALTER COLUMN id SET DEFAULT nextval('project_licenses_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY project_reports ALTER COLUMN id SET DEFAULT nextval('project_reports_id_seq'::regclass);
 
 
@@ -4442,6 +4282,20 @@ ALTER TABLE ONLY project_reports ALTER COLUMN id SET DEFAULT nextval('project_re
 --
 
 ALTER TABLE ONLY project_vulnerability_reports ALTER COLUMN id SET DEFAULT nextval('project_vulnerability_reports_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY projects ALTER COLUMN id SET DEFAULT nextval('projects_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY ratings ALTER COLUMN id SET DEFAULT nextval('ratings_id_seq'::regclass);
 
 
 --
@@ -4476,6 +4330,13 @@ ALTER TABLE ONLY reports ALTER COLUMN id SET DEFAULT nextval('reports_id_seq'::r
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
+ALTER TABLE ONLY repositories ALTER COLUMN id SET DEFAULT nextval('repositories_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY reverification_pilot_accounts ALTER COLUMN id SET DEFAULT nextval('reverification_pilot_accounts_id_seq'::regclass);
 
 
@@ -4490,7 +4351,70 @@ ALTER TABLE ONLY reverification_trackers ALTER COLUMN id SET DEFAULT nextval('re
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY settings ALTER COLUMN id SET DEFAULT nextval('settings_id_seq'::regclass);
+ALTER TABLE ONLY reviews ALTER COLUMN id SET DEFAULT nextval('reviews_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY rss_articles ALTER COLUMN id SET DEFAULT nextval('rss_articles_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY rss_feeds ALTER COLUMN id SET DEFAULT nextval('rss_feeds_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY rss_subscriptions ALTER COLUMN id SET DEFAULT nextval('rss_subscriptions_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY sessions ALTER COLUMN id SET DEFAULT nextval('sessions_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY slave_logs ALTER COLUMN id SET DEFAULT nextval('slave_logs_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY slaves ALTER COLUMN id SET DEFAULT nextval('slave_permissions_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY sloc_metrics ALTER COLUMN id SET DEFAULT nextval('sloc_metrics_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY sloc_sets ALTER COLUMN id SET DEFAULT nextval('sloc_sets_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY stack_entries ALTER COLUMN id SET DEFAULT nextval('stack_entries_id_seq'::regclass);
 
 
 --
@@ -4498,6 +4422,27 @@ ALTER TABLE ONLY settings ALTER COLUMN id SET DEFAULT nextval('settings_id_seq':
 --
 
 ALTER TABLE ONLY stack_ignores ALTER COLUMN id SET DEFAULT nextval('stack_ignores_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY stacks ALTER COLUMN id SET DEFAULT nextval('stacks_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY taggings ALTER COLUMN id SET DEFAULT nextval('taggings_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY tags ALTER COLUMN id SET DEFAULT nextval('tags_id_seq'::regclass);
 
 
 --
@@ -4512,6 +4457,13 @@ ALTER TABLE ONLY thirty_day_summaries ALTER COLUMN id SET DEFAULT nextval('thirt
 --
 
 ALTER TABLE ONLY tools ALTER COLUMN id SET DEFAULT nextval('tools_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY topics ALTER COLUMN id SET DEFAULT nextval('topics_id_seq'::regclass);
 
 
 --
@@ -4688,6 +4640,22 @@ ALTER TABLE ONLY clumps
 
 
 --
+-- Name: code_locations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY code_locations
+    ADD CONSTRAINT code_locations_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: code_locations_unique_repository_id_module_branch_name; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY code_locations
+    ADD CONSTRAINT code_locations_unique_repository_id_module_branch_name UNIQUE (repository_id, module_branch_name);
+
+
+--
 -- Name: code_set_gestalts_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -4784,14 +4752,6 @@ ALTER TABLE ONLY enlistments
 
 
 --
--- Name: event_subscription_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
---
-
-ALTER TABLE ONLY event_subscription
-    ADD CONSTRAINT event_subscription_pkey PRIMARY KEY (id);
-
-
---
 -- Name: exhibits_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -4869,14 +4829,6 @@ ALTER TABLE ONLY fyles
 
 ALTER TABLE ONLY gestalts
     ADD CONSTRAINT gestalts_pkey PRIMARY KEY (id);
-
-
---
--- Name: github_project_project_id_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
---
-
-ALTER TABLE ONLY github_project
-    ADD CONSTRAINT github_project_project_id_key UNIQUE (project_id, owner);
 
 
 --
@@ -5104,30 +5056,6 @@ ALTER TABLE ONLY names
 
 
 --
--- Name: oauth_access_grants_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
---
-
-ALTER TABLE ONLY oauth_access_grants
-    ADD CONSTRAINT oauth_access_grants_pkey PRIMARY KEY (id);
-
-
---
--- Name: oauth_access_tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
---
-
-ALTER TABLE ONLY oauth_access_tokens
-    ADD CONSTRAINT oauth_access_tokens_pkey PRIMARY KEY (id);
-
-
---
--- Name: oauth_applications_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
---
-
-ALTER TABLE ONLY oauth_applications
-    ADD CONSTRAINT oauth_applications_pkey PRIMARY KEY (id);
-
-
---
 -- Name: oauth_nonces_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -5173,22 +5101,6 @@ ALTER TABLE ONLY people
 
 ALTER TABLE ONLY permissions
     ADD CONSTRAINT permissions_pkey PRIMARY KEY (id);
-
-
---
--- Name: pg_ts_cfg_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
---
-
-ALTER TABLE ONLY pg_ts_cfg
-    ADD CONSTRAINT pg_ts_cfg_pkey PRIMARY KEY (ts_name);
-
-
---
--- Name: pg_ts_cfgmap_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
---
-
-ALTER TABLE ONLY pg_ts_cfgmap
-    ADD CONSTRAINT pg_ts_cfgmap_pkey PRIMARY KEY (ts_name, tok_alias);
 
 
 --
@@ -5408,14 +5320,6 @@ ALTER TABLE ONLY sessions
 
 
 --
--- Name: settings_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
---
-
-ALTER TABLE ONLY settings
-    ADD CONSTRAINT settings_pkey PRIMARY KEY (id);
-
-
---
 -- Name: slave_logs_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -5568,19 +5472,19 @@ ALTER TABLE ONLY project_gestalts
 
 
 --
+-- Name: unique_project_id_code_location_id; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY enlistments
+    ADD CONSTRAINT unique_project_id_code_location_id UNIQUE (project_id, code_location_id);
+
+
+--
 -- Name: unique_project_id_name_id; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY positions
     ADD CONSTRAINT unique_project_id_name_id UNIQUE (project_id, name_id);
-
-
---
--- Name: unique_project_id_repository_id; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
---
-
-ALTER TABLE ONLY enlistments
-    ADD CONSTRAINT unique_project_id_repository_id UNIQUE (project_id, repository_id);
 
 
 --
@@ -5643,27 +5547,6 @@ CREATE INDEX edits_organization_id ON edits USING btree (organization_id) WHERE 
 --
 
 CREATE INDEX edits_project_id ON edits USING btree (project_id) WHERE (project_id IS NOT NULL);
-
-
---
--- Name: foo; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX foo ON slaves USING btree (clump_status) WHERE (oldest_clump_timestamp IS NOT NULL);
-
-
---
--- Name: github_project_owner_idx; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX github_project_owner_idx ON github_project USING btree (owner);
-
-
---
--- Name: github_project_project_id_idx; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX github_project_project_id_idx ON github_project USING btree (project_id);
 
 
 --
@@ -5765,13 +5648,6 @@ CREATE INDEX index_analysis_sloc_sets_on_analysis_id_sloc_set_id ON analysis_slo
 
 
 --
--- Name: index_analysis_sloc_sets_on_sloc_set_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_analysis_sloc_sets_on_sloc_set_id ON analysis_sloc_sets USING btree (sloc_set_id);
-
-
---
 -- Name: index_analysis_summaries_on_analysis_id_type; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -5783,13 +5659,6 @@ CREATE INDEX index_analysis_summaries_on_analysis_id_type ON analysis_summaries 
 --
 
 CREATE INDEX index_api_keys_on_key ON api_keys USING btree (key);
-
-
---
--- Name: index_api_keys_on_oauth_application_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_api_keys_on_oauth_application_id ON api_keys USING btree (oauth_application_id);
 
 
 --
@@ -5821,6 +5690,20 @@ CREATE INDEX index_clumps_on_code_set_id_slave_id ON clumps USING btree (code_se
 
 
 --
+-- Name: index_code_locations_on_best_code_set_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_code_locations_on_best_code_set_id ON code_locations USING btree (best_code_set_id);
+
+
+--
+-- Name: index_code_locations_on_repository_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_code_locations_on_repository_id ON code_locations USING btree (repository_id);
+
+
+--
 -- Name: index_code_set_gestalts_on_code_set_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -5842,6 +5725,13 @@ CREATE INDEX index_code_sets_on_best_sloc_set_id ON code_sets USING btree (best_
 
 
 --
+-- Name: index_code_sets_on_code_location_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_code_sets_on_code_location_id ON code_sets USING btree (code_location_id);
+
+
+--
 -- Name: index_code_sets_on_logged_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -5853,13 +5743,6 @@ CREATE INDEX index_code_sets_on_logged_at ON code_sets USING btree ((COALESCE(lo
 --
 
 CREATE INDEX index_code_sets_on_repository_id ON code_sets USING btree (repository_id);
-
-
---
--- Name: index_commit_flags_on_commit_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_commit_flags_on_commit_id ON commit_flags USING btree (commit_id);
 
 
 --
@@ -5954,6 +5837,13 @@ CREATE INDEX index_edits_on_edits ON edits USING btree (target_type, target_id, 
 
 
 --
+-- Name: index_enlistments_on_code_location_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_enlistments_on_code_location_id ON enlistments USING btree (code_location_id);
+
+
+--
 -- Name: index_enlistments_on_project_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -6045,6 +5935,13 @@ CREATE INDEX index_jobs_on_account_id ON jobs USING btree (account_id);
 
 
 --
+-- Name: index_jobs_on_code_location_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_jobs_on_code_location_id ON jobs USING btree (code_location_id);
+
+
+--
 -- Name: index_jobs_on_code_set_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -6059,10 +5956,10 @@ CREATE INDEX index_jobs_on_project_id ON jobs USING btree (project_id);
 
 
 --
--- Name: index_jobs_on_repository_id_status; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_jobs_on_repository_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
-CREATE INDEX index_jobs_on_repository_id_status ON jobs USING btree (repository_id, status);
+CREATE INDEX index_jobs_on_repository_id ON jobs USING btree (repository_id);
 
 
 --
@@ -6098,13 +5995,6 @@ CREATE INDEX index_kudo_scores_on_account_id ON kudo_scores USING btree (account
 --
 
 CREATE INDEX index_kudo_scores_on_array_index ON kudo_scores USING btree (array_index);
-
-
---
--- Name: index_kudo_scores_on_project_id_name_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_kudo_scores_on_project_id_name_id ON kudo_scores USING btree (project_id, name_id);
 
 
 --
@@ -6255,41 +6145,6 @@ CREATE INDEX index_names_on_name ON names USING btree (name);
 
 
 --
--- Name: index_oauth_access_grants_on_token; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE UNIQUE INDEX index_oauth_access_grants_on_token ON oauth_access_grants USING btree (token);
-
-
---
--- Name: index_oauth_access_tokens_on_refresh_token; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE UNIQUE INDEX index_oauth_access_tokens_on_refresh_token ON oauth_access_tokens USING btree (refresh_token);
-
-
---
--- Name: index_oauth_access_tokens_on_resource_owner_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_oauth_access_tokens_on_resource_owner_id ON oauth_access_tokens USING btree (resource_owner_id);
-
-
---
--- Name: index_oauth_access_tokens_on_token; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE UNIQUE INDEX index_oauth_access_tokens_on_token ON oauth_access_tokens USING btree (token);
-
-
---
--- Name: index_oauth_applications_on_uid; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE UNIQUE INDEX index_oauth_applications_on_uid ON oauth_applications USING btree (uid);
-
-
---
 -- Name: index_on_commits_code_set_id_position; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -6322,13 +6177,6 @@ CREATE UNIQUE INDEX index_organizations_on_name ON organizations USING btree (lo
 --
 
 CREATE INDEX index_organizations_on_vector ON organizations USING gin (vector);
-
-
---
--- Name: index_people_gin; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_people_gin ON people USING gin (vector);
 
 
 --
@@ -6521,13 +6369,6 @@ CREATE INDEX index_repositories_on_best_code_set_id ON repositories USING btree 
 
 
 --
--- Name: index_repositories_on_forge_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_repositories_on_forge_id ON repositories USING btree (forge_id);
-
-
---
 -- Name: index_reviews_on_account_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -6567,13 +6408,6 @@ CREATE INDEX index_rss_subscriptions_project_id ON rss_subscriptions USING btree
 --
 
 CREATE INDEX index_sessions_on_session_id ON sessions USING btree (session_id);
-
-
---
--- Name: index_settings_on_key; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE UNIQUE INDEX index_settings_on_key ON settings USING btree (key);
 
 
 --
@@ -6696,13 +6530,6 @@ CREATE UNIQUE INDEX kudos_uniques ON kudos USING btree (sender_id, (COALESCE(acc
 
 
 --
--- Name: people_on_name_fact_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX people_on_name_fact_id ON people USING btree (name_fact_id);
-
-
---
 -- Name: posts_account_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -6714,13 +6541,6 @@ CREATE INDEX posts_account_id ON posts USING btree (account_id);
 --
 
 CREATE INDEX posts_topic_ic ON posts USING btree (topic_id);
-
-
---
--- Name: robin; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX robin ON name_facts USING btree (last_checkin) WHERE (type = 'VitaFact'::text);
 
 
 --
@@ -6923,7 +6743,7 @@ ALTER TABLE ONLY analysis_sloc_sets
 --
 
 ALTER TABLE ONLY analysis_summaries
-    ADD CONSTRAINT analysis_summaries_analysis_id_fkey FOREIGN KEY (analysis_id) REFERENCES analyses(id);
+    ADD CONSTRAINT analysis_summaries_analysis_id_fkey FOREIGN KEY (analysis_id) REFERENCES analyses(id) ON DELETE CASCADE;
 
 
 --
@@ -6988,6 +6808,14 @@ ALTER TABLE ONLY clumps
 
 ALTER TABLE ONLY clumps
     ADD CONSTRAINT clumps_slave_id_fkey FOREIGN KEY (slave_id) REFERENCES slaves(id) ON DELETE CASCADE;
+
+
+--
+-- Name: code_locations_best_code_set_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY code_locations
+    ADD CONSTRAINT code_locations_best_code_set_id_fkey FOREIGN KEY (best_code_set_id) REFERENCES code_sets(id);
 
 
 --
@@ -7175,38 +7003,6 @@ ALTER TABLE ONLY enlistments
 
 
 --
--- Name: event_subscription_account_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY event_subscription
-    ADD CONSTRAINT event_subscription_account_id_fkey FOREIGN KEY (account_id) REFERENCES accounts(id) ON DELETE CASCADE;
-
-
---
--- Name: event_subscription_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY event_subscription
-    ADD CONSTRAINT event_subscription_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE;
-
-
---
--- Name: event_subscription_subscriber_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY event_subscription
-    ADD CONSTRAINT event_subscription_subscriber_id_fkey FOREIGN KEY (subscriber_id) REFERENCES accounts(id) ON DELETE CASCADE;
-
-
---
--- Name: event_subscription_topic_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY event_subscription
-    ADD CONSTRAINT event_subscription_topic_id_fkey FOREIGN KEY (topic_id) REFERENCES topics(id) ON DELETE CASCADE;
-
-
---
 -- Name: exhibits_report_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7255,11 +7051,11 @@ ALTER TABLE ONLY project_vulnerability_reports
 
 
 --
--- Name: fk_rails_8faa63554c; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_0ff5ad97b1; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY api_keys
-    ADD CONSTRAINT fk_rails_8faa63554c FOREIGN KEY (oauth_application_id) REFERENCES oauth_applications(id);
+ALTER TABLE ONLY code_locations
+    ADD CONSTRAINT fk_rails_0ff5ad97b1 FOREIGN KEY (repository_id) REFERENCES repositories(id);
 
 
 --
@@ -7935,14 +7731,6 @@ ALTER TABLE ONLY rss_subscriptions
 
 
 --
--- Name: sfprojects_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY sfprojects
-    ADD CONSTRAINT sfprojects_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects(id);
-
-
---
 -- Name: slave_logs_code_set_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7964,6 +7752,14 @@ ALTER TABLE ONLY slave_logs
 
 ALTER TABLE ONLY slave_logs
     ADD CONSTRAINT slave_logs_slave_id_fkey FOREIGN KEY (slave_id) REFERENCES slaves(id) ON DELETE CASCADE;
+
+
+--
+-- Name: sloc_metrics_diff_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY sloc_metrics
+    ADD CONSTRAINT sloc_metrics_diff_id_fkey FOREIGN KEY (diff_id) REFERENCES diffs(id) ON DELETE CASCADE;
 
 
 --
@@ -8260,9 +8056,11 @@ INSERT INTO schema_migrations (version) VALUES ('20160317061932');
 
 INSERT INTO schema_migrations (version) VALUES ('20160318131123');
 
+INSERT INTO schema_migrations (version) VALUES ('20160321061931');
+
 INSERT INTO schema_migrations (version) VALUES ('20160504111046');
 
-INSERT INTO schema_migrations (version) VALUES ('20160608090419');
+INSERT INTO schema_migrations (version) VALUES ('20160512144023');
 
 INSERT INTO schema_migrations (version) VALUES ('21');
 


### PR DESCRIPTION
Ran [migration](https://github.com/blackducksoftware/ohloh/pull/1074/commits/5a3b565204c1f3ffc77c2ebc61bfb72115710d06) in ohloh codebase using the staging environment.
Ran `RAILS_ENV=staging rake db:structure:dump` in ohloh-ui to update structure.sql.
We are looking for ohloh-ui tests to pass with this updated structure.sql.
