### PR TITLE
[OTWO-4328] Rss Feeds Fetch: Remove duplicate feeds from collection of new feeds

### DIFF
--- a/app/models/rss_article.rb
+++ b/app/models/rss_article.rb
@@ -25,5 +25,9 @@ class RssArticle < ActiveRecord::Base
     def guid_from_item(item)
       Digest::SHA1.hexdigest([item[:title], item[:url], item[:summary]].compact.join('|'))
     end
+
+    def remove_duplicates(articles)
+      articles.map(&:guid).uniq.map { |guid| articles.detect { |article| article.guid == guid } }
+    end
   end
 end

--- a/app/models/rss_feed.rb
+++ b/app/models/rss_feed.rb
@@ -45,7 +45,7 @@ class RssFeed < ActiveRecord::Base
 
   def create_rss_articles
     new_articles = new_rss_article_items.map { |item| RssArticle.from_item(item) }
-    rss_articles << new_articles
+    rss_articles << RssArticle.remove_duplicates(new_articles)
     projects.update_all(updated_at: Time.current) unless new_articles.empty?
   end
 

--- a/fixtures/vcr_cassettes/RssFeedDuplicate.yml
+++ b/fixtures/vcr_cassettes/RssFeedDuplicate.yml
@@ -1,0 +1,79 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://www.vcrlocalhost.org/duplicate-feeds.rss
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Ohloh.net client
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 20 Mar 2015 13:59:50 GMT
+      Content-Type:
+        - application/rss; charset=utf-8
+      Connection:
+      - close
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '1882'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Vary:
+      - Accept-Encoding, User-Agent
+    body:
+      encoding: utf-8
+      string: '<?xml version="1.0" encoding="utf-8"?>
+        <rss version="2.0">
+        <channel>
+        <title>Apple Hot News</title>
+        <link>http://www.apple.com/hotnews/</link>
+        <description>Hot News provided by Apple.</description>
+        <language>en-us</language>
+        <copyright>Copyright 2015, Apple Inc.</copyright>
+        <pubDate>Mon, 27 Apr 2015 14:50:30 PDT</pubDate>
+        <lastBuildDate>Mon, 27 Apr 2015 14:50:30 PDT</lastBuildDate>
+        <category>Apple</category>
+        <generator>In house</generator>
+        <docs>http://blogs.law.harvard.edu/tech/rss/</docs>
+        <item>
+        <title>It will display ÀāĎĠĦž</title>
+        <description></description>
+        </item>
+        </channel>
+
+        <channel>
+        <title>Apple Hot News</title>
+        <link>http://www.apple.com/hotnews/</link>
+        <description>Hot News provided by Apple.</description>
+        <language>en-us</language>
+        <copyright>Copyright 2015, Apple Inc.</copyright>
+        <pubDate>Mon, 27 Apr 2015 14:50:30 PDT</pubDate>
+        <lastBuildDate>Mon, 27 Apr 2015 14:50:30 PDT</lastBuildDate>
+        <category>Apple</category>
+        <generator>In house</generator>
+        <docs>http://blogs.law.harvard.edu/tech/rss/</docs>
+        <item>
+        <title>It will display ÀāĎĠĦž</title>
+        <description></description>
+        </item>
+        </channel>
+        </rss>'
+    http_version:
+  recorded_at: Fri, 20 Mar 2015 14:00:43 GMT
+recorded_with: VCR 2.9.3


### PR DESCRIPTION
PG::UniqueViolation error is encountered while trying to update rss feeds that has bunch of new feeds with some duplicate feeds. It is addressed by removing the duplicate new feeds before saving them into database.
