### PR TITLE
Fix display of flash message in new project create

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -31,7 +31,8 @@ class ProjectsController < ApplicationController
     if @project.save
       redirect_to project_path(@project)
     else
-      render :check_forge, status: :unprocessable_entity, notice: t('.failure')
+      flash.now[:error] = t('.failure')
+      render :check_forge, status: :unprocessable_entity
     end
   end
 

--- a/config/locales/projects.en.yml
+++ b/config/locales/projects.en.yml
@@ -240,7 +240,7 @@ en:
     update:
       success: "Project changes were saved successfully!"
     create:
-      failure: "There was a problem!"
+      failure: "There was a problem and the repository could not be verified.  Please check URL and branch."
     estimated_cost:
       page_title: "The %{name} Open Source Project on Open Hub : Estimated Cost Page"
       estimated_cost: "Estimated Cost"

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -996,6 +996,75 @@ ALTER SEQUENCE clumps_id_seq OWNED BY clumps.id;
 
 
 --
+-- Name: code_location_events; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE code_location_events (
+    id integer NOT NULL,
+    code_location_id integer,
+    type text NOT NULL,
+    value text,
+    commit_sha1 text,
+    status boolean,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: code_location_events_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE code_location_events_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: code_location_events_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE code_location_events_id_seq OWNED BY code_location_events.id;
+
+
+--
+-- Name: code_locations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE code_locations (
+    id integer NOT NULL,
+    repository_id integer,
+    module_branch_name text,
+    status integer DEFAULT 1,
+    best_code_set_id integer,
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone
+);
+
+
+--
+-- Name: code_locations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE code_locations_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: code_locations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE code_locations_id_seq OWNED BY code_locations.id;
+
+
+--
 -- Name: code_set_gestalts; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -4325,6 +4394,20 @@ ALTER TABLE ONLY clumps ALTER COLUMN id SET DEFAULT nextval('clumps_id_seq'::reg
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
+ALTER TABLE ONLY code_location_events ALTER COLUMN id SET DEFAULT nextval('code_location_events_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY code_locations ALTER COLUMN id SET DEFAULT nextval('code_locations_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY code_set_gestalts ALTER COLUMN id SET DEFAULT nextval('code_set_gestalts_id_seq'::regclass);
 
 
@@ -4842,6 +4925,22 @@ ALTER TABLE ONLY positions
 
 ALTER TABLE ONLY clumps
     ADD CONSTRAINT clumps_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: code_location_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY code_location_events
+    ADD CONSTRAINT code_location_events_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: code_locations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY code_locations
+    ADD CONSTRAINT code_locations_pkey PRIMARY KEY (id);
 
 
 --
@@ -5967,6 +6066,34 @@ CREATE INDEX index_claims_on_account_id ON positions USING btree (account_id);
 --
 
 CREATE INDEX index_clumps_on_code_set_id_slave_id ON clumps USING btree (code_set_id, slave_id);
+
+
+--
+-- Name: index_code_location_events_on_code_location_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_code_location_events_on_code_location_id ON code_location_events USING btree (code_location_id);
+
+
+--
+-- Name: index_code_locations_on_best_code_set_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_code_locations_on_best_code_set_id ON code_locations USING btree (best_code_set_id);
+
+
+--
+-- Name: index_code_locations_on_repository_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_code_locations_on_repository_id ON code_locations USING btree (repository_id);
+
+
+--
+-- Name: index_code_locations_on_repository_id_and_module_branch_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE UNIQUE INDEX index_code_locations_on_repository_id_and_module_branch_name ON code_locations USING btree (repository_id, module_branch_name);
 
 
 --
@@ -7404,6 +7531,30 @@ ALTER TABLE ONLY project_vulnerability_reports
 
 
 --
+-- Name: fk_rails_0ff5ad97b1; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY code_locations
+    ADD CONSTRAINT fk_rails_0ff5ad97b1 FOREIGN KEY (repository_id) REFERENCES repositories(id);
+
+
+--
+-- Name: fk_rails_2f22a538c9; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY code_locations
+    ADD CONSTRAINT fk_rails_2f22a538c9 FOREIGN KEY (best_code_set_id) REFERENCES code_sets(id);
+
+
+--
+-- Name: fk_rails_5a0f61d9a6; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY code_location_events
+    ADD CONSTRAINT fk_rails_5a0f61d9a6 FOREIGN KEY (code_location_id) REFERENCES code_locations(id);
+
+
+--
 -- Name: fk_rails_8faa63554c; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -8413,9 +8564,13 @@ INSERT INTO schema_migrations (version) VALUES ('20160321061931');
 
 INSERT INTO schema_migrations (version) VALUES ('20160504111046');
 
+INSERT INTO schema_migrations (version) VALUES ('20160512144023');
+
 INSERT INTO schema_migrations (version) VALUES ('20160608090419');
 
 INSERT INTO schema_migrations (version) VALUES ('20160608194402');
+
+INSERT INTO schema_migrations (version) VALUES ('20160610142302');
 
 INSERT INTO schema_migrations (version) VALUES ('21');
 

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -619,6 +619,7 @@ describe 'ProjectsController' do
     must_select 'input#project_enlistments_attributes_0_repository_attributes_url'
     must_select 'input#project_enlistments_attributes_0_repository_attributes_branch_name'
     must_select 'select#repository_type'
+    flash[:error].must_equal I18n.t('projects.create.failure')
   end
 
   it 'create should gracefully handle validation errors' do


### PR DESCRIPTION
It looks like we were never able to display the flash message in the New
Project create action. A user was having difficulty adding their project
because they had the wrong branch, but there was no error. To them, it
seemed like the page simply refreshed when it was failing silently.

The fix is was to ensure the error flash was being populated.  Note that
this is a change from the use of the notice flash, which had been the
implemention.  However, it is the authors opinion that failure to save
should be indicated by an error message, instead of a notice.
