### PR TITLE
OTWO-4843 - Add additional failure group categories to capture uncate…

### DIFF
--- a/script/insert_new_failure_groups.rb
+++ b/script/insert_new_failure_groups.rb
@@ -1,0 +1,31 @@
+#! /usr/bin/env ruby
+
+raise 'RAILS_ENV is undefined' unless ENV['RAILS_ENV']
+
+require_relative '../config/environment'
+
+# rubocop:disable LineLength
+ActiveRecord::Base.connection.execute("
+
+INSERT INTO failure_groups(
+	name, pattern, priority, auto_reschedule)
+	VALUES
+    ('Investigate: SVN path not found', '%svn%path not found%', 0, false),
+    ('Investigate: Invalid revision range', '%fatal: Invalid revision range%', 0, false),
+    ('Investigate: Name/service not known', '%Name or service not known%', 0, false),
+    ('Investigate: Invalid URL', '%Unable to connect to a repository at URL%', 0, false),
+    ('Investigate: No common commits', '%no common commits%', 0, false),
+    ('Investigate: Unknown revision default', '%abort: unknown revision%', 0, false),
+    ('Investigate: conversion of nil into string', '%no implicit conversion of nil into String%', 0, false),
+    ('Investigate: sha1 already taken', '%Validation failed: Commit sha1 has already been taken%', 0, false),
+    ('Investigate: Not a tar archive', '%This does not look like a tar archive%', 0, false),
+    ('Investigate: Parse error - missing argument', '%hg: parse error: missing argument%', 0, false),
+    ('Investigate: allow unknown type', '%usage: git cat-file (-t [--allow-unknown-type]%', 0, false),
+    ('Investigate: tarball - Syntax error', '%Syntax error:%', 0, false),
+    ('Investigate: not a git repository', '%does not appear to be a git repository%', 0, false),
+    ('Investigate: Unknown device/address','%fatal: could not read Username for%No such device or address%', 0, false),
+    ('Investigate: Ambiguous argument - unknown revision', '%fatal: ambiguous argument%unknown revision or path not in the working tree%', 0, false),
+    ('Investigate: Non fast-forward', '%(non-fast-forward)%', 0, false) ;")
+
+# rubocop:enable LineLength
+FailureGroup.categorize


### PR DESCRIPTION
…gorized failed jobs.

Created new script that creates new failure group records and categorizes failed jobs that were not originally categorized.
Final results - ability to categorize ~ 150k uncategorized jobs.  

Please review the new failure groups  - they are all set not to auto_reschedule.  Not sure if that is correct in all instances.  Let me know if you think any of the groups should be set to auot_reschedule.