### PR TITLE
OTWO-4815 - Update Enlistments Undo buttons when a project has been d…

### DIFF
--- a/app/assets/javascripts/edit.js.coffee
+++ b/app/assets/javascripts/edit.js.coffee
@@ -42,18 +42,39 @@ class Edit
     else if location.pathname.match('/accounts/')
       BUTTON_TYPES['account']
 
-  setupUndoOrRedo: ->
-    $(@editButton).unbind('click').html('Working...')
-    $.ajax
-      object_id: @objectId
-      type: 'POST'
-      url: "/edits/#{@objectId}?ajax=1&#{@buttonType()}=#{@parentId}"
-      data: {_method: 'put', undo: @undoOrRedoFlag }
-      success: (data, textStatus) =>
-        $("#edit_#{@objectId}").replaceWith(data)
-        new Edit($("#edit_#{@objectId}").find('.undo, .redo'))
-      error: (xml_http_request, textStatus, errorThrown) ->
-        alert("Error: #{errorThrown}")
+   setupUndoOrRedo: ->
+      $(@editButton).unbind('click').html('Working...')
+      $.ajax
+        object_id: @objectId
+        type: 'POST'
+        url: "/edits/#{@objectId}?ajax=1&#{@buttonType()}=#{@parentId}"
+        data: {_method: 'put', undo: @undoOrRedoFlag }
+        success: (data, textStatus) =>
+          $("#edit_#{@objectId}").replaceWith(data)
+          new Edit($("#edit_#{@objectId}").find('.undo, .redo'))
+
+          if $(@editButton).hasClass('project') && @undoOrRedoFlag
+            @refreshEnlistment()
+        error: (xml_http_request, textStatus, errorThrown) ->
+              alert("Error: #{errorThrown}")
+
+   refreshEnlistment: ->
+    enlistments = $('.enlistment.undo')
+    i = 0
+    while i < enlistments.length
+      element = enlistments[i]
+      @objectId = $(element).closest('tr')[0].id.slice(5)
+      $.ajax
+       type: 'GET'
+       url: "/p/#{@parentId}/edits/refresh/#{@objectId}?ajax=1"
+       success: (data, textStatus) ->
+        tr = $(data).closest('tr').attr('id')
+        $('#' + tr).replaceWith(data)
+
+       error: (xml_http_request, textStatus, errorThrown) ->
+        alert 'Error: ' + errorThrown
+      i++
+
 
 $(document).on 'page:change', ->
   $('.edit').find('.undo, .redo').each -> new Edit($(this))

--- a/app/controllers/edits_controller.rb
+++ b/app/controllers/edits_controller.rb
@@ -2,9 +2,9 @@ class EditsController < SettingsController
   helper ProjectsHelper
 
   before_action :session_required, :redirect_unverified_account, only: [:update]
-  before_action :find_parent, only: [:index, :show, :update]
+  before_action :find_parent, only: [:index, :show, :update, :refresh]
   before_action :show_permissions_alert, only: :index, unless: :parent_is_account_or_license?
-  before_action :find_edit, only: [:show, :update]
+  before_action :find_edit, only: [:show, :update, :refresh]
   before_action :find_edits, only: [:index]
 
   def index
@@ -13,6 +13,10 @@ class EditsController < SettingsController
 
   def show
     render nothing: true, status: :ok unless request.xhr?
+  end
+
+  def refresh
+    render template: 'edits/edit', layout: false
   end
 
   def update

--- a/app/views/edits/_undo_block.html.haml
+++ b/app/views/edits/_undo_block.html.haml
@@ -1,7 +1,7 @@
 - if edit.undone?
   - can_redo = edit.allow_redo?
   - if edit.target.edit_authorized? && can_redo
-    %a.btn.btn-mini.btn-warning{ href: '#', class: needs_login_or_verification_or_default(:redo) }
+    %a.btn.btn-mini.btn-warning{ href: '#', :class => " #{needs_login_or_verification_or_default(:redo)} #{edit.target_type.downcase if edit.type == 'CreateEdit'}" }
       %i.icon-repeat= t('.redo')
   - else
     - btn_text = "<i class='icon-repeat'></i> #{can_redo ? t('.redo') : t('.cant_redo')}"
@@ -13,7 +13,7 @@
 - else
   - can_undo = edit.allow_undo?
   - if edit.target.edit_authorized? && can_undo
-    %a.btn.btn-mini.btn-primary{ href: '#', class: needs_login_or_verification_or_default(:undo) }
+    %a.btn.btn-mini.btn-primary{ href: '#', :class => " #{needs_login_or_verification_or_default(:undo)} #{edit.target_type.downcase if edit.type == 'CreateEdit'}" }
       %i.icon-undo= t('.undo')
   - else
     - btn_text = "<i class='icon-undo'></i> #{can_undo ? t('.undo') : t('.cant_undo')}"

--- a/app/views/edits/_undo_block.html.haml
+++ b/app/views/edits/_undo_block.html.haml
@@ -1,7 +1,8 @@
 - if edit.undone?
   - can_redo = edit.allow_redo?
+  - target_css = edit.target_type.downcase if edit.type == 'CreateEdit'
   - if edit.target.edit_authorized? && can_redo
-    %a.btn.btn-mini.btn-warning{ href: '#', :class => " #{needs_login_or_verification_or_default(:redo)} #{edit.target_type.downcase if edit.type == 'CreateEdit'}" }
+    %a.btn.btn-mini.btn-warning{ href: '#', class: "#{needs_login_or_verification_or_default(:redo)} #{target_css}" }
       %i.icon-repeat= t('.redo')
   - else
     - btn_text = "<i class='icon-repeat'></i> #{can_redo ? t('.redo') : t('.cant_redo')}"
@@ -13,7 +14,7 @@
 - else
   - can_undo = edit.allow_undo?
   - if edit.target.edit_authorized? && can_undo
-    %a.btn.btn-mini.btn-primary{ href: '#', :class => " #{needs_login_or_verification_or_default(:undo)} #{edit.target_type.downcase if edit.type == 'CreateEdit'}" }
+    %a.btn.btn-mini.btn-primary{ href: '#', class: "#{needs_login_or_verification_or_default(:undo)} #{target_css}" }
       %i.icon-undo= t('.undo')
   - else
     - btn_text = "<i class='icon-undo'></i> #{can_undo ? t('.undo') : t('.cant_undo')}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -253,6 +253,7 @@ Rails.application.routes.draw do
     end
     resources :manages, only: [:new]
     resources :edits, only: [:index, :show]
+    get 'edits/refresh/:id', to: 'edits#refresh'
     resources :enlistments
     resources :factoids, only: [:index]
     resources :rss_articles, only: :index


### PR DESCRIPTION
…eleted

To test - Go to the last edit page and ensure that there are at least one enlistment creation edits on the page.  Press undo on the project creation.  You should see the project creation and all enlistments on the page set to Redo.    If possible find a project that has multiple enlistments on the same page as the project creation and see that all enlistments are deleted and set to redo.