### PR TITLE
OTWO-4864 Fixed the forward slash on Badges

### DIFF
--- a/app/core_extensions/ruby/string.rb
+++ b/app/core_extensions/ruby/string.rb
@@ -24,6 +24,10 @@ class String
     text
   end
 
+  def escape_single_quote
+    gsub("'", "\\\\'")
+  end
+
   def valid_http_url?
     URI.parse(self).is_a?(URI::HTTP)
   rescue URI::InvalidURIError

--- a/app/models/widget/project_widget/partner_badge.rb
+++ b/app/models/widget/project_widget/partner_badge.rb
@@ -12,7 +12,7 @@ class ProjectWidget::PartnerBadge < ProjectWidget
   end
 
   def image
-    image_data = [{ text: project.name.truncate(16).shellescape, align: :center }]
+    image_data = [{ text: project.name.truncate(16).escape_single_quote, align: :center }]
     image_data += [lines_text, cost_text, head_count_text] if analysis.present?
 
     WidgetBadge::Partner.create(image_data)

--- a/app/models/widget/project_widget/thin_badge.rb
+++ b/app/models/widget/project_widget/thin_badge.rb
@@ -12,7 +12,7 @@ class ProjectWidget::ThinBadge < ProjectWidget
   end
 
   def image
-    image_data = [{ text: project.name.truncate(18).shellescape, align: :center }]
+    image_data = [{ text: project.name.truncate(18).escape_single_quote, align: :center }]
     image_data += [lines_text, cost_text, head_count_text] if analysis.present?
     image_data += [{ text: 'Metrics by Open Hub', align: :center }]
     WidgetBadge::Thin.create(image_data)


### PR DESCRIPTION
the imagemagick breaks only when single quote is encountered. So when a string has "fon'tli" ..it breaks.

```ruby
MiniMagick::Error (`convert -size 150x26 xc:white -font /home/vagrant/projects/ohloh-ui/app/assets/fonts/OpenSans-Regular.ttf -fill rgb( 0%, 0%, 0% ) -stroke #0099ff -pointsize 14 -weight 350 -gravity North -draw text 0,3 'fo n'tli' /tmp/image-base-20170727-10609-b156cp.png` failed with error:
```
So now the shellword is removed and we're escaping single quote so that the forward slash(\) won't appear in the Badges.