### PR TITLE
OTWO-4856 Fix committers#index memory hog

### DIFF
--- a/test/controllers/committers_controller_test.rb
+++ b/test/controllers/committers_controller_test.rb
@@ -28,8 +28,12 @@ describe 'CommittersControllerTest' do
       must_render_template :index
     end
 
-    it 'must limit results when it exceeds OBJECT_MEMORY_CAP' do
+    it 'must limit queried results when it exceeds OBJECT_MEMORY_CAP' do
       UnclaimedControllerTest.limit_by_memory_cap(self)
+    end
+
+    it 'must limit results when it exceeds OBJECT_MEMORY_CAP' do
+      UnclaimedControllerTest.limit_by_memory_cap(self, false)
     end
 
     it 'should not return if query is not found' do

--- a/test/support/unclaimed_controller_test.rb
+++ b/test/support/unclaimed_controller_test.rb
@@ -1,5 +1,5 @@
 module UnclaimedControllerTest
-  def limit_by_memory_cap(instance)
+  def limit_by_memory_cap(instance, with_query = true)
     original_object_memory_cap = OBJECT_MEMORY_CAP
     limit = UNCLAIMED_TILE_LIMIT + 1
     Object.send(:remove_const, 'OBJECT_MEMORY_CAP')
@@ -9,8 +9,9 @@ module UnclaimedControllerTest
     name_fact = name.name_facts.first
     instance.create_list(:person, limit + 2, name: name, name_fact: name_fact)
 
-    instance.get :index, query: name.name
-    instance.assigns(:unclaimed_people)[0][1].length.must_equal UNCLAIMED_TILE_LIMIT
+    instance.get :index, query: (name.name if with_query)
+    people = instance.assigns(:unclaimed_people).find { |list| list[0] == name.id }[1]
+    people.length.must_equal UNCLAIMED_TILE_LIMIT
 
     Object.send(:remove_const, 'OBJECT_MEMORY_CAP')
     Object.const_set('OBJECT_MEMORY_CAP', original_object_memory_cap)


### PR DESCRIPTION
This fixes the case where a high number of people objects cause memory hog in the default index results.
