### PR TITLE
OTWO-4928  - Script to delete obsolete GoogleCode projects

### DIFF
--- a/app/controllers/edits_controller.rb
+++ b/app/controllers/edits_controller.rb
@@ -31,7 +31,6 @@ class EditsController < SettingsController
 
   def perform_undo
     @edit.undo!(current_user)
-    @parent.after_undo(current_user)
   end
 
   def parent_is_account_or_license?

--- a/app/models/edit.rb
+++ b/app/models/edit.rb
@@ -54,12 +54,17 @@ class Edit < ActiveRecord::Base
   end
 
   def swap_doneness(undo, editor)
-    raise I18n.t('edits.undo_redo_require_editor') unless editor
-    raise ActsAsEditable::UndoError, I18n.t(undo ? 'edits.cant_undo' : 'edits.cant_redo') if undone == undo
+    check_exceptions(undo, editor)
     Edit.transaction do
       undo ? do_undo : do_redo
       update_attributes!(undone: undo, undone_at: Time.current, undone_by: editor.id)
+      target.after_undo(editor) if undo && target.respond_to?(:after_undo)
     end
+  end
+
+  def check_exceptions(undo, editor)
+    raise I18n.t('edits.undo_redo_require_editor') unless editor
+    raise ActsAsEditable::UndoError, I18n.t(undo ? 'edits.cant_undo' : 'edits.cant_redo') if undone == undo
   end
 
   def populate_project

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,6 +1,7 @@
 # rubocop:disable Metrics/ClassLength
 
 class Project < ActiveRecord::Base
+  has_one :create_edit, as: :target
   acts_as_editable editable_attributes: [:name, :vanity_url, :organization_id, :best_analysis_id,
                                          :description, :tag_list, :missing_source, :url, :download_url],
                    merge_within: 30.minutes


### PR DESCRIPTION
Also made a change to allow for project.undo will also perform enlistment.undo.  Refactored code that was in controller and put it into the Edit model.