### PR TITLE
OTWO-4963 Fix enlistments sort by Update Status

### DIFF
--- a/app/models/enlistment.rb
+++ b/app/models/enlistment.rb
@@ -30,7 +30,7 @@ class Enlistment < ActiveRecord::Base
   }
   scope :by_update_status, lambda {
     joins('left join jobs on jobs.code_location_id = enlistments.code_location_id')
-      .group('enlistments.id').order('min(jobs.status)')
+      .group('enlistments.id').order('min(jobs.status), max(jobs.current_step_at) DESC')
   }
 
   filterable_by ['projects.name', 'repositories.url', 'code_locations.module_branch_name', 'repositories.type']

--- a/test/controllers/enlistments_controller_test.rb
+++ b/test/controllers/enlistments_controller_test.rb
@@ -217,6 +217,18 @@ describe 'EnlistmentsControllerTest' do
       Enlistment.count.must_equal 3
     end
 
+    it 'must update code_location.repository if code_location already exists' do
+      code_location = create(:code_location)
+      repository = code_location.repository
+      new_repository = build(:repository, url: repository.url, username: Faker::Name.name)
+
+      post :create, project_id: @project_id, repository: new_repository.attributes,
+                    code_location: code_location.attributes
+
+      must_redirect_to action: :index
+      Repository.find(repository.id).username.must_equal new_repository.username
+    end
+
     it 'must show alert message for adding the first enlistment' do
       post :create, project_id: @project_id, repository: code_location.repository.attributes,
                     code_location: code_location.attributes

--- a/test/models/enlistment_test.rb
+++ b/test/models/enlistment_test.rb
@@ -32,12 +32,18 @@ class EnlistmentTest < ActiveSupport::TestCase
       Enlistment.by_last_update.count.must_equal 1
     end
 
-    it 'should order based on the jobs last executed' do
-      code_location1 = create(:code_location)
-      code_location2 = create(:code_location)
-      create(:failed_job, code_location: code_location2, current_step_at: 1.month.ago)
-      create(:fetch_job, code_location: code_location1, current_step_at: 5.minutes.ago)
-      Enlistment.by_update_status.must_equal [code_location2.enlistments.first, code_location1.enlistments.first]
+    it 'should order based on the jobs.status and current_step_at' do
+      cl_1 = create(:code_location)
+      cl_2 = create(:code_location)
+      cl_3 = create(:code_location)
+      cl_4 = create(:code_location)
+      Job.destroy_all
+      create(:failed_job, code_location: cl_4, current_step_at: 1.minute.ago)
+      create(:sloc_job, code_location: cl_3, current_step_at: 1.day.ago)
+      create(:complete_job, code_location: cl_2, current_step_at: 1.month.ago)
+      create(:failed_job, code_location: cl_2, current_step_at: 1.hour.ago)
+      create(:fetch_job, code_location: cl_1, current_step_at: 1.week.ago)
+      Enlistment.by_update_status.pluck(:code_location_id).must_equal [cl_2.id, cl_3.id, cl_1.id, cl_4.id]
     end
   end
 


### PR DESCRIPTION
Sorting by *Update Status* should first sort by status and then sort by last updated job.
Also fixed the intermittently failing test.
