### PR TITLE
Remove timeout plugin to debug memory hog

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,6 @@ gem 'whenever', require: false
 gem 'sidekiq'
 gem 'secondbase'
 gem 'simplemde-rails'
-gem 'slowpoke'
 gem 'jwt'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,7 +143,6 @@ GEM
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
-    errbase (0.0.3)
     erubis (2.7.0)
     eventmachine (1.2.0.1)
     execjs (2.7.0)
@@ -358,7 +357,6 @@ GEM
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
-    rack-timeout (0.4.2)
     rails (4.2.7.1)
       actionmailer (= 4.2.7.1)
       actionpack (= 4.2.7.1)
@@ -436,8 +434,6 @@ GEM
     ruby_parser (3.8.2)
       sexp_processor (~> 4.1)
     safe_yaml (1.0.4)
-    safely_block (0.2.0)
-      errbase
     sass (3.5.1)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -468,10 +464,6 @@ GEM
       simplecov (>= 0.4.1)
     simplemde-rails (1.10.2)
     slop (3.6.0)
-    slowpoke (0.1.3)
-      rack-timeout (>= 0.3.0)
-      rails
-      safely_block
     spring (1.7.2)
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
@@ -590,7 +582,6 @@ DEPENDENCIES
   simplecov
   simplecov-rcov
   simplemde-rails
-  slowpoke
   spring
   sprockets-rails (~> 2.3.3)
   teaspoon-jasmine

--- a/config/initializers/slowpoke_setup.rb
+++ b/config/initializers/slowpoke_setup.rb
@@ -1,1 +1,0 @@
-Slowpoke.timeout = 30 # lower timeout values block Admin dashboard.


### PR DESCRIPTION
Timeout prevents memory bloat from occuring. We need to investigate the memory bloat in order to fix it.
