### PR TITLE
Ignore TarballJobs when scheduling a fetch

### DIFF
--- a/app/models/project_license.rb
+++ b/app/models/project_license.rb
@@ -7,7 +7,7 @@ class ProjectLicense < ActiveRecord::Base
 
   validates :license_id, presence: true,
                          uniqueness: { scope: :project_id }
-  validates :license_id, numericality: {greater_than: 0}
+  validates :license_id, numericality: { greater_than: 0 }
 
   def allow_redo?(_key)
     license.deleted? ? false : true

--- a/test/factories/jobs.rb
+++ b/test/factories/jobs.rb
@@ -29,4 +29,9 @@ FactoryBot.define do
     type 'CompleteJob'
     status Job::STATUS_FAILED
   end
+
+  factory :failed_tarball_job, parent: :job do
+    type 'TarballJob'
+    status Job::STATUS_FAILED
+  end
 end

--- a/test/models/code_location_test.rb
+++ b/test/models/code_location_test.rb
@@ -155,6 +155,15 @@ class CodeLocationTest < ActiveSupport::TestCase
       code_location.schedule_fetch
       code_location.do_not_fetch.must_equal false
     end
+
+    it 'should schedule a complete job even if there is a failed TarballJob' do
+      code_location = create(:code_location, :with_code_set, do_not_fetch: true)
+      clear_jobs
+      create(:failed_tarball_job, code_location: code_location, code_set: code_location.best_code_set)
+      code_location.jobs.count.must_equal 1
+      code_location.schedule_fetch
+      code_location.jobs.count.must_equal 2
+    end
   end
 
   describe 'repository_directory' do


### PR DESCRIPTION
The Code Location "schedule_fetch" would return if there were any
incomplete jobs, ostensibly because those jobs need to be completed
first.

However, the existence of a TarballJob causes problems with this. The
Project and Code Locations are not dependent upon a TarballJob
successfully completing. However, if there was a failed TarballJob, the
"incomplete" state is true, and no new job would be created.

The fix in this change set is to filter out TarballJobs from the set of
incomplete or new jobs (those that finished within the last 5 minutes).
Frankly, the author has some concerns about this blanket 5 minute
policy, but isn't attempting to address it now.

The test code illustrates that the TarballJob must belong to the Code
Location and have the Code Locations's best code set recoreded as well
because the "schedule_fetch" logic looks at the Code Set's jobs.

There is also a small rubocop fix to the Project License model.