### PR TITLE
OTWO-5039 Restore login with email

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -255,8 +255,7 @@ class ApplicationController < ActionController::Base
   end
 
   def redirect_for_spammer_verification
-    #return if current_user && !current_user.access.disabled? && current_user.access.mobile_or_oauth_verified?
-    return if current_user  && current_user.access.mobile_or_oauth_verified?
+    return if current_user && current_user.access.mobile_or_oauth_verified?
     redirect_to new_authentication_path
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -255,7 +255,7 @@ class ApplicationController < ActionController::Base
   end
 
   def redirect_for_spammer_verification
-    return if current_user && current_user.access.mobile_or_oauth_verified?
+    return if current_user && !current_user.access.disabled? && current_user.access.mobile_or_oauth_verified?
     redirect_to new_authentication_path
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -255,7 +255,8 @@ class ApplicationController < ActionController::Base
   end
 
   def redirect_for_spammer_verification
-    return if current_user && !current_user.access.disabled? && current_user.access.mobile_or_oauth_verified?
+    #return if current_user && !current_user.access.disabled? && current_user.access.mobile_or_oauth_verified?
+    return if current_user  && current_user.access.mobile_or_oauth_verified?
     redirect_to new_authentication_path
   end
 

--- a/app/controllers/concerns/clearance_setup.rb
+++ b/app/controllers/concerns/clearance_setup.rb
@@ -5,7 +5,7 @@ module ClearanceSetup
     include Clearance::Controller
 
     def authenticate(params)
-      account = Account.find_by_login(params[:login][:login])
+      account = Account.fetch_by_login_or_email(params[:login][:login])
       return unless account
       return account if account.authenticated?(params[:login][:password])
     end

--- a/test/lib/clearance_test.rb
+++ b/test/lib/clearance_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+class ClearanceTest < ActiveSupport::TestCase
+  describe 'logging in' do
+    before do
+      @myclass = ClearanceTestModel.new
+      @account = create(:account, password: 'mypassword')
+    end
+
+    it 'should authenticate by login' do
+      @myclass.authenticate(login: { login: @account.login, password: 'mypassword' }).id.must_equal @account.id
+    end
+
+    it 'should authenticate by email' do
+      @myclass.authenticate(login: { login: @account.email, password: 'mypassword' }).id.must_equal @account.id
+    end
+  end
+end
+
+class ClearanceTestModel
+  include ClearanceSetup
+end


### PR DESCRIPTION
With the migration to Clearance, we lost the ability to login with an
email address.  This restores that feature.

There was also a regression failure where a disabled account was being
redirected to the "authenticate new" path. This was due to the
"!current_user.access.disabled?" in the
ApplicationController#redirect_for_spammer_verification method.  When a
user is disabled, then they'll get caught by a later before_action
filter, so this check isn't needed here.