### PR TITLE
Fixed i18n compatible issue

### DIFF
--- a/config/locales/accounts.en.yml
+++ b/config/locales/accounts.en.yml
@@ -205,7 +205,7 @@ en:
       note_bullet_1: 'Accounts must be created for an individual.'
       note_bullet_2: 'Accounts created to represent a company will be disabled.'
       note_bullet_3: 'Accounts created for the purpose of advertising, link generation, marketing, or SEO, etc. will be disabled.'
-      we_dont_like_disabling: "We don\'t like disabling accounts any more than you would like to have your account disabled, but we like it even less when folks try to abuse this free service. Please help us keep the Open Hub a useful service to all. Thanks!"
+      we_dont_like_disabling: "We don't like disabling accounts any more than you would like to have your account disabled, but we like it even less when folks try to abuse this free service. Please help us keep the Open Hub a useful service to all. Thanks!"
       welcome_bullet_1: 'Claim all of your commits to projects across all of Open Hub, building a complete picture of your contributions to FOSS.'
       welcome_bullet_2: 'Manage projects.'
       welcome_bullet_3: 'Create project "stacks" that detail your usage of FOSS, and rate and review the projects you know.'

--- a/config/locales/deleted_accounts.en.yml
+++ b/config/locales/deleted_accounts.en.yml
@@ -4,7 +4,7 @@ en:
       expired: 'Sorry, Page expired.'
       invalid_request: 'Sorry, Invalid request!'
       sad: 'We are sorry to see you go...'
-      info: "Your account has been deleted. Any contributions you had claimed under your account have been placed back in the pool of unclaimed contributions on Open Hub. They\'re still visible, just not associated with you through an account."
+      info: "Your account has been deleted. Any contributions you had claimed under your account have been placed back in the pool of unclaimed contributions on Open Hub. They're still visible, just not associated with you through an account."
       rejoin: "You can rejoin Open Hub any time you like - just click the 'Join' button in the upper right on any Open Hub page and set up a new account. We hope you'll consider returning in the future!"
       feedback: "Please take a moment to let us know why you're deleting your account. We're constantly striving to make Open Hub better, and your feedback is important to us!"
     update:

--- a/config/locales/organizations.en.yml
+++ b/config/locales/organizations.en.yml
@@ -102,7 +102,7 @@ en:
       failed: 'Failed.'
     remove_project:
       success: 'Removed %{name} successfully'
-      error: "Error! Couldn\'t remove this project."
+      error: "Error! Couldn't remove this project."
     show:
       loading: 'Loading.....'
       page_title: '%{organization_name} : Organization Summary - Open Hub'


### PR DESCRIPTION
Fixed the issue on OSX when running rake or ay other commands
`I18n::InvalidLocaleData: can not load translations from config/locales/accounts.en.yml: #<Psych::SyntaxError: (accounts.en.yml): found unknown escape character while parsing a quoted scalar`