### PR TITLE
Updated the link checker scripts to capture only broken links

### DIFF
--- a/lib/tasks/check_broken_links.rake
+++ b/lib/tasks/check_broken_links.rake
@@ -13,13 +13,8 @@ task check_broken_links: :environment do
 end
 
 def valid_url?(url)
-  uri = URI.parse(url)
-  if uri.is_a?(URI::HTTP) && !uri.host.nil?
-    res = Net::HTTP.get_response(u)
-    ['200'].include?(res.code)
-  else
-    false
-  end
+  uri = URI.parse(url.gsub(' ', '%20'))
+  uri.is_a?(URI::HTTP) && !uri.host.nil?
 rescue URI::InvalidURIError
   false
 end


### PR DESCRIPTION
The script was capturing all the links with below errors:
 ```Errno::ECONNREFUSED
 Net::HTTPBadResponse
 Errno::EHOSTUNREACH
 Zlib::BufError
 OpenSSL::SSL::SSLError
 Errno::ENETUNREACH
 URI::InvalidURIError
 Errno::ECONNRESET
 Net::ReadTimeout
 SocketError
 Errno::ETIMEDOUT
 EOFError
```
Updated the scripts to capture links which raises `URI::InvalidURIError` error.