### PR TITLE
OTWO-5418 Fixed the github login to do case insensitive search by account login

### DIFF
--- a/app/assets/javascripts/github_auth.js.coffee
+++ b/app/assets/javascripts/github_auth.js.coffee
@@ -3,6 +3,7 @@ class App.GithubAuth
 
   authenticate: ($githubButton) ->
     $githubButton.click ->
+      $(this).attr 'disabled', 'disabled'
       github_url_params = [
         AUTH_URL
         '?client_id=', $(this).data('clientId')

--- a/app/controllers/authentications_controller.rb
+++ b/app/controllers/authentications_controller.rb
@@ -56,6 +56,7 @@ class AuthenticationsController < ApplicationController
 
   def github_api_account
     @account ||= Account.find_by(email: github_api.email)
+    @account ||= Account.where(email: github_api.secondary_emails).first
   end
 
   def redirect_matching_account

--- a/app/models/account/login_formatter.rb
+++ b/app/models/account/login_formatter.rb
@@ -19,7 +19,7 @@ class Account
 
     def get_unique_login(clean_login)
       login = clean_login
-      while Account.exists?(login: login) || login.length < 3
+      while Account.resolve_login(login).present? || login.length < 3
         login = clean_login + Random.rand(999).to_s
       end
       login

--- a/test/models/account/login_formatter_test.rb
+++ b/test/models/account/login_formatter_test.rb
@@ -20,5 +20,12 @@ class LoginFormatterTest < ActiveSupport::TestCase
       sanitized_login = Account::LoginFormatter.new(login).sanitized_and_unique
       sanitized_login.must_match(/#{ login }\d{1,3}/)
     end
+
+    it 'must return a value that does not match an existing account.login case insensitively' do
+      account = create(:account)
+      login = account.login.upcase
+      sanitized_login = Account::LoginFormatter.new(login).sanitized_and_unique
+      sanitized_login.must_match(/#{ login }\d{1,3}/)
+    end
   end
 end


### PR DESCRIPTION
- This PR will also add functionality to check for an account matching with Github secondary email addresses.
- Also avoid multiple click on Sign in with Github. 