### PR TITLE
this migration shouldn't be in ohloh-ui

### DIFF
--- a/db/migrate/20190529010101_alter_slave_and_jobs_table.rb
+++ b/db/migrate/20190529010101_alter_slave_and_jobs_table.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-class AlterSlaveAndJobsTable < ActiveRecord::Migration
-  def change
-    add_column :slaves, :queue_name, :string
-    add_column :jobs, :is_expensive, :boolean, default: false, index: true
-  end
-end


### PR DESCRIPTION
This PR removes an inadvertent migration meant for the fisbot database (and not ohloh-ui).  It's presence in ohloh-ui hinders running the server; ie after a db refresh/reload, the server expects the migration to be present and generates a respective migration error until this issue is resolved manually in the ohloh-ui database.  Thanks  to @msk999 for helping to identify and resolve this issue.