### PR TITLE
OTWO-5751 Ohloh UI: Replace gem rubocop by rubocop-rails

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,7 +38,7 @@ Lint/ScriptPermission:
   Exclude:
     - script/*
 
-Documentation:
+Style/Documentation:
   Enabled: false
 
 Style/ClassAndModuleChildren:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,10 +9,6 @@ AllCops:
 Rails:
   Enabled: true
 
-Rails/SkipsModelValidations:
-  Exclude:
-    - 'test/**/*.rb'
-
 Rails/UnknownEnv:
   Environments:
     - production

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,10 @@ AllCops:
 Rails:
   Enabled: true
 
+Rails/SkipsModelValidations:
+  Exclude:
+    - 'test/**/*.rb'
+
 Rails/UnknownEnv:
   Environments:
     - production

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,20 @@
+require: rubocop-rails
+
 AllCops:
   TargetRubyVersion: 2.5
   Exclude:
     - vagrant/**/*
     - script/*_temp.rb
+
+Rails:
+  Enabled: true
+
+Rails/UnknownEnv:
+  Environments:
+    - production
+    - development
+    - test
+    - staging
 
 Metrics/LineLength:
   Max: 120

--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem 'rbnacl-libsodium'
 gem 'recaptcha', require: 'recaptcha/rails'
 gem 'redcarpet'
 gem 'redis-rails', '>= 5.0.2'
-gem 'rubocop', require: false
+gem 'rubocop-rails', require: false
 gem 'rubocop-rspec', '> 1.28'
 gem 'sass-rails'
 gem 'secondbase'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -250,7 +250,7 @@ GEM
       has_scope (~> 0.6)
       railties (>= 4.2, < 5.3)
       responders
-    jaro_winkler (1.5.3)
+    jaro_winkler (1.5.4)
     jasmine-core (2.99.2)
     jasmine-jquery-rails (2.0.3)
     jasmine-rails (0.14.8)
@@ -352,8 +352,8 @@ GEM
       mime-types
       mimemagic (~> 0.3.0)
       terrapin (~> 0.6.0)
-    parallel (1.17.0)
-    parser (2.6.3.0)
+    parallel (1.18.0)
+    parser (2.6.5.0)
       ast (~> 2.4.0)
     path_expander (1.0.3)
     pg (0.20.0)
@@ -449,13 +449,16 @@ GEM
     responders (2.4.1)
       actionpack (>= 4.2.0, < 6.0)
       railties (>= 4.2.0, < 6.0)
-    rubocop (0.74.0)
+    rubocop (0.76.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.6)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-rails (2.3.2)
+      rack (>= 1.1)
+      rubocop (>= 0.72.0)
     rubocop-rspec (1.32.0)
       rubocop (>= 0.60.0)
     ruby-graphviz (1.2.4)
@@ -629,7 +632,7 @@ DEPENDENCIES
   recaptcha
   redcarpet
   redis-rails (>= 5.0.2)
-  rubocop
+  rubocop-rails
   rubocop-rspec (> 1.28)
   ruby_parser
   sass-rails
@@ -657,4 +660,4 @@ DEPENDENCIES
   will_paginate-bootstrap
 
 BUNDLED WITH
-   1.17.3
+   2.0.2

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,6 +37,10 @@ class ApplicationController < ActionController::Base
     super(*params)
   end
 
+  def index; end
+
+  def show; end
+
   def validate_request_format
     render_404 if request.format.nil?
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable SkipsModelValidations
 # rubocop:disable Metrics/ClassLength
 class ApplicationController < ActionController::Base
   include ClearanceSetup
@@ -318,3 +319,4 @@ class ApplicationController < ActionController::Base
   end
 end
 # rubocop:enable Metrics/ClassLength
+# rubocop:enable SkipsModelValidations

--- a/app/controllers/concerns/enlistment_filters.rb
+++ b/app/controllers/concerns/enlistment_filters.rb
@@ -17,6 +17,20 @@ module EnlistmentFilters
     before_action :project_has_code_location?, only: :create
   end
 
+  def create; end
+
+  def new; end
+
+  def index; end
+
+  def show; end
+
+  def edit; end
+
+  def update; end
+
+  def destroy; end
+
   private
 
   def enlistment_params

--- a/app/controllers/concerns/org_filters.rb
+++ b/app/controllers/concerns/org_filters.rb
@@ -21,6 +21,18 @@ module OrgFilters
     before_action :avoid_global_search, only: %i[manage_projects claim_projects_list]
   end
 
+  def create; end
+
+  def new; end
+
+  def index; end
+
+  def show; end
+
+  def edit; end
+
+  def update; end
+
   def schedule_analysis
     @organization.schedule_analysis
   end

--- a/app/controllers/concerns/org_filters.rb
+++ b/app/controllers/concerns/org_filters.rb
@@ -4,6 +4,7 @@ module OrgFilters
   extend ActiveSupport::Concern
 
   included do
+    # rubocop: disable LexicallyScopedActionFilter
     before_action :set_organization, except: %i[index new create
                                                 resolve_vanity_url print_org_infographic update]
     before_action :set_organization_based_on_id, only: [:update]
@@ -19,6 +20,7 @@ module OrgFilters
     before_action :can_claim_project, only: :claim_project
     after_action :schedule_analysis, only: %i[claim_project remove_project]
     before_action :avoid_global_search, only: %i[manage_projects claim_projects_list]
+    # rubocop: enable LexicallyScopedActionFilter
   end
 
   def create; end

--- a/app/controllers/concerns/position_filters.rb
+++ b/app/controllers/concerns/position_filters.rb
@@ -18,6 +18,20 @@ module PositionFilters
     helper_method :params_id_is_total?
   end
 
+  def create; end
+
+  def new; end
+
+  def show; end
+
+  def edit; end
+
+  def udpate; end
+
+  def delete; end
+
+  def destroy; end
+
   private
 
   def set_account

--- a/app/controllers/concerns/position_filters.rb
+++ b/app/controllers/concerns/position_filters.rb
@@ -4,6 +4,7 @@ module PositionFilters
   extend ActiveSupport::Concern
 
   included do
+    # rubocop: disable LexicallyScopedActionFilter
     before_action :session_required, :redirect_unverified_account,
                   only: %i[edit new create delete one_click_create]
     before_action :set_account
@@ -16,6 +17,7 @@ module PositionFilters
     before_action :set_project_and_name_fact, only: :commits_compound_spark
     skip_before_action :store_location, only: [:commits_compound_spark]
     helper_method :params_id_is_total?
+    # rubocop: enable LexicallyScopedActionFilter
   end
 
   def create; end
@@ -26,7 +28,7 @@ module PositionFilters
 
   def edit; end
 
-  def udpate; end
+  def update; end
 
   def delete; end
 

--- a/app/controllers/concerns/project_filters.rb
+++ b/app/controllers/concerns/project_filters.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable SkipsModelValidations
+
 module ProjectFilters
   extend ActiveSupport::Concern
 
@@ -68,3 +70,5 @@ module ProjectFilters
     @project.update_column('uuid', uuid) if uuid
   end
 end
+
+# rubocop:enable SkipsModelValidations

--- a/app/controllers/concerns/project_filters.rb
+++ b/app/controllers/concerns/project_filters.rb
@@ -6,6 +6,7 @@ module ProjectFilters
   extend ActiveSupport::Concern
 
   included do
+    # rubocop: disable LexicallyScopedActionFilter
     before_action :session_required, :redirect_unverified_account, only: %i[check_forge create new update]
     before_action :find_account
     before_action :find_projects, only: [:index]
@@ -21,6 +22,7 @@ module ProjectFilters
     before_action :set_uuid, only: :show
     before_action :avoid_global_search_if_parent_is_account, only: :index
     before_action :avoid_global_search, only: :users
+    # rubocop: enable LexicallyScopedActionFilter
   end
 
   def create; end

--- a/app/controllers/concerns/project_filters.rb
+++ b/app/controllers/concerns/project_filters.rb
@@ -23,6 +23,18 @@ module ProjectFilters
     before_action :avoid_global_search, only: :users
   end
 
+  def create; end
+
+  def new; end
+
+  def index; end
+
+  def show; end
+
+  def edit; end
+
+  def update; end
+
   private
 
   def avoid_global_search_if_parent_is_account

--- a/app/controllers/concerns/vulnerability_filters.rb
+++ b/app/controllers/concerns/vulnerability_filters.rb
@@ -13,6 +13,8 @@ module VulnerabilityFilters
 
   def index; end
 
+  def filter; end
+
   private
 
   def find_best_security_set

--- a/app/controllers/concerns/vulnerability_filters.rb
+++ b/app/controllers/concerns/vulnerability_filters.rb
@@ -11,6 +11,8 @@ module VulnerabilityFilters
     before_action :find_vulnerability_data, only: [:index]
   end
 
+  def index; end
+
   private
 
   def find_best_security_set

--- a/app/controllers/logos_controller.rb
+++ b/app/controllers/logos_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable SkipsModelValidations
+
 class LogosController < SettingsController
   helper ManagersHelper
   helper ProjectsHelper
@@ -82,3 +84,5 @@ class LogosController < SettingsController
     params.require(:logo).permit(:logo, :url, :attachment)
   end
 end
+
+# rubocop:enable SkipsModelValidations

--- a/app/controllers/oh_admin/license_permissions_controller.rb
+++ b/app/controllers/oh_admin/license_permissions_controller.rb
@@ -7,6 +7,8 @@ class OhAdmin::LicensePermissionsController < ApplicationController
   layout 'admin'
   include LicenseHelper
 
+  def update; end
+
   def index
     retrieve_license_permissions
     retrieve_licenses

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable SkipsModelValidations
+
 class OrganizationsController < ApplicationController
   helper ProjectsHelper
   helper RatingsHelper
@@ -124,3 +126,5 @@ class OrganizationsController < ApplicationController
     end
   end
 end
+
+# rubocop:enable SkipsModelValidations

--- a/app/controllers/privacy_controller.rb
+++ b/app/controllers/privacy_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable SkipsModelValidations
+
 class PrivacyController < ApplicationController
   before_action :session_required, :redirect_unverified_account, only: %i[edit update]
   before_action :set_account
@@ -46,3 +48,5 @@ class PrivacyController < ApplicationController
     params.require(:account).permit(:email_master, :email_kudos, :email_posts)
   end
 end
+
+# rubocop:enable SkipsModelValidations

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable DynamicFindBy
+
 class ReviewsController < ApplicationController
   helper RatingsHelper
   helper ProjectsHelper
@@ -88,3 +90,5 @@ class ReviewsController < ApplicationController
     redirect_to summary_project_reviews_path(@project), flash: { error: t(:not_authorized) }
   end
 end
+
+# rubocop:enable DynamicFindBy

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -4,6 +4,12 @@ class SettingsController < ApplicationController
   before_action :show_permissions_alert, only: %i[index new edit]
   ACCEPTABLE_TIME_UNITS = %w[hours days weeks months years].freeze
 
+  def index; end
+
+  def new; end
+
+  def edit; end
+
   def oversized_project?(project)
     return true if defined?(OVERSIZED_PROJECT_IDS) && OVERSIZED_PROJECT_IDS.include?(project.id)
   end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -11,6 +11,8 @@ class TagsController < ApplicationController
 
   def index; end
 
+  def select; end
+
   private
 
   def find_tag_names

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -8,6 +8,7 @@ class TagsController < ApplicationController
   before_action :find_tag_names, only: :index
   before_action :find_models, only: [:index]
   before_action :show_permissions_alert, only: :select
+
   def index; end
 
   private

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable SkipsModelValidations
+
 class TopicsController < ApplicationController
   helper MarkdownHelper
   before_action :session_required, :redirect_unverified_account, only: %i[new create close reopen]
@@ -112,3 +114,5 @@ class TopicsController < ApplicationController
     topic_params[:account_id] == topic_params[:posts_attributes]['0'][:account_id]
   end
 end
+
+# rubocop:enable SkipsModelValidations

--- a/app/controllers/widgets_controller.rb
+++ b/app/controllers/widgets_controller.rb
@@ -10,6 +10,8 @@ class WidgetsController < ApplicationController
   before_action :handle_xml_format, except: :index
   skip_before_action :verify_authenticity_token
 
+  def index; end
+
   private
 
   def record_not_found

--- a/app/decorators/badge_decorator.rb
+++ b/app/decorators/badge_decorator.rb
@@ -11,7 +11,8 @@ class BadgeDecorator < Cherry::Decorator
   def pips_url(request)
     return nil unless (1..15).cover?(level)
 
-    file = BADGE_IMAGE_ROOT + format('pips_%02i.png', level)
+    level_hash = { level: level }
+    file = BADGE_IMAGE_ROOT + format('pips_%<level>02i.png', level_hash)
     base_url(request) + file
   end
 

--- a/app/helpers/abouts_helper.rb
+++ b/app/helpers/abouts_helper.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module AboutsHelper
-  def compute_style_for_language_tag(language)
+  def compute_style_for_language_tag(language, sum)
     # Take the percentage of the sum of all language totals and then decrease by a factor of 8 rounding to 2 places
-    em = @languages_total_sum.zero? ? 0.0 : ((language.total.fdiv(@languages_total_sum) * 100.0) / 8.0).round(2)
+    em = sum.zero? ? 0.0 : ((language.total.fdiv(sum) * 100.0) / 8.0).round(2)
     weight = em >= 0.1 && em <= 1.1 ? 'bold' : 'normal'
     em = [em, 1.1].max
     em = [em, 3.5].min

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -122,10 +122,10 @@ module ApplicationHelper
     number
   end
 
-  def highlight(actual_time, base_time = nil)
+  def highlight(highlight_from, actual_time, base_time = nil)
     return if actual_time.blank?
 
-    base_time ||= @highlight_from || Time.current
+    base_time ||= highlight_from || Time.current
     return 'highlight' if actual_time >= base_time
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -138,9 +138,11 @@ module ApplicationHelper
     will_paginate(numbers.paginate(page: response['current_page'], per_page: response['per_page']))
   end
 
+  # rubocop: disable Rails/OutputSafety
   def safe_text(str)
     safe_join(Array(str.html_safe))
   end
+  # rubocop: enable Rails/OutputSafety
 
   private
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,7 +13,7 @@ module ApplicationHelper
     err = model.errors[attr]
     return '' if err.blank?
 
-    haml_tag 'p', [err].flatten.join('<br />').html_safe, opts.reverse_merge(class: 'error').merge(rel: attr)
+    haml_tag 'p', safe_text([err].flatten.join('<br />')), opts.reverse_merge(class: 'error').merge(rel: attr)
   end
 
   def password_error_tag(model, attr, opts = {})
@@ -21,7 +21,7 @@ module ApplicationHelper
     return '' if err.blank? || err == ["can't be blank"]
 
     err = err.first if err.size == 2
-    haml_tag 'p', [err].flatten.join('<br />').html_safe, opts.reverse_merge(class: 'error').merge(rel: attr)
+    haml_tag 'p', safe_text([err].flatten.join('<br />')), opts.reverse_merge(class: 'error').merge(rel: attr)
   end
 
   def project_pages_title(page_name = nil, project_name = nil)
@@ -41,11 +41,11 @@ module ApplicationHelper
     return unless text
 
     text = text.sanitize
-    return text.html_safe if text.length < max
+    return safe_text(text) if text.length < max
 
     l = (text[0..min].rindex(regex) || min + 1) + regex_offset
     l -= 1 if text[l..l] == ','
-    render_expander(text, l).html_safe
+    safe_text(render_expander(text, l))
   end
 
   def pluralize_without_count(count, singular, plural = nil)
@@ -136,6 +136,10 @@ module ApplicationHelper
   def api_pagination(response)
     numbers = (1..response['total_entries']).to_a
     will_paginate(numbers.paginate(page: response['current_page'], per_page: response['per_page']))
+  end
+
+  def safe_text(str)
+    safe_join(Array(str.html_safe))
   end
 
   private

--- a/app/helpers/avatar_helper.rb
+++ b/app/helpers/avatar_helper.rb
@@ -35,15 +35,15 @@ module AvatarHelper
   end
 
   def avatar_small_laurels(rank)
-    avatar_laurels_img(rank, 'sm_laurel').html_safe
+    safe_text(avatar_laurels_img(rank, 'sm_laurel'))
   end
 
   def avatar_laurels(rank)
-    avatar_laurels_img(rank, 'laurel').html_safe
+    safe_text(avatar_laurels_img(rank, 'laurel'))
   end
 
   def avatar_tiny_laurels(rank)
-    avatar_laurels_img(rank, 'tn_laurel').html_safe
+    safe_text(avatar_laurels_img(rank, 'tn_laurel'))
   end
 
   private
@@ -82,6 +82,6 @@ module AvatarHelper
   end
 
   def avatar_laurels_img(rank, imag_base)
-    "<img src='" + image_path("icons/#{imag_base}_#{rank || 1}.png") + "' alt='KudoRank #{rank || 1}'/>".html_safe
+    safe_text("<img src='" + image_path("icons/#{imag_base}_#{rank || 1}.png") + "' alt='KudoRank #{rank || 1}'/>")
   end
 end

--- a/app/helpers/blog_link_helper.rb
+++ b/app/helpers/blog_link_helper.rb
@@ -25,7 +25,7 @@ module BlogLinkHelper
   }.freeze
 
   def blog_link_to(link:, link_text:)
-    "<a class='meta' href='http://blog.openhub.net/#{BLOG_LINKS[link]}' target='_blank'>#{link_text}</a>".html_safe
+    safe_text("<a class='meta' href='http://blog.openhub.net/#{BLOG_LINKS[link]}' target='_blank'>#{link_text}</a>")
   end
 
   def blog_url_for(article_name)

--- a/app/helpers/blog_link_helper.rb
+++ b/app/helpers/blog_link_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module BlogLinkHelper
+  include ApplicationHelper
+
   BLOG_LINKS = {
     terms: 'terms',
     additional_terms: 'terms-2',

--- a/app/helpers/bootstrap_helper.rb
+++ b/app/helpers/bootstrap_helper.rb
@@ -2,6 +2,6 @@
 
 module BootstrapHelper
   def bootstrap_icon(name, text = nil)
-    "<i class='#{name}'>#{text == '' ? '' : '&nbsp;'}</i>#{text || ''}".html_safe
+    safe_text("<i class='#{name}'>#{text == '' ? '' : '&nbsp;'}</i>#{text || ''}")
   end
 end

--- a/app/helpers/button_helper.rb
+++ b/app/helpers/button_helper.rb
@@ -3,11 +3,11 @@
 module ButtonHelper
   def disabled_button(text, opts = {})
     css_class = "#{opts[:class]} #{needs_login_or_verification_or_default(:disabled)}".strip
-    link_to text.html_safe, 'javascript:', class: "btn #{css_class}"
+    link_to safe_text(text), 'javascript:', class: "btn #{css_class}"
   end
 
   def icon_button(url, options = {})
-    linked_text = "<i class='icon-#{options.delete(:icon)}'>&nbsp;</i>#{options.delete(:text)}".html_safe
+    linked_text = safe_text("<i class='icon-#{options.delete(:icon)}'>&nbsp;</i>#{options.delete(:text)}")
     link_to(linked_text, url, { class: "btn btn-#{options.delete(:size)} btn-#{options.delete(:type)}" }.merge(options))
   end
 end

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module DashboardHelper
+  include ApplicationHelper
+
   def accounts_link(level)
     "/admin/accounts?q%5Blevel_eq%5D=#{level}&commit=Filter&order=id_desc"
   end
@@ -15,7 +17,7 @@ module DashboardHelper
     link_text = " (#{revision[0..7]}) "
     deployed = time_ago_in_words(file_modified) + ' ago '
     link = link_to(link_text, github_url, style: 'color: #fff', target: '_blank', rel: 'noopener')
-    safe_text((deployed + link))
+    safe_text(deployed + link)
   end
 
   def get_revision_details

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -15,7 +15,7 @@ module DashboardHelper
     link_text = " (#{revision[0..7]}) "
     deployed = time_ago_in_words(file_modified) + ' ago '
     link = link_to(link_text, github_url, style: 'color: #fff', target: '_blank', rel: 'noopener')
-    (deployed + link).html_safe
+    safe_text((deployed + link))
   end
 
   def get_revision_details

--- a/app/helpers/edits_helper.rb
+++ b/app/helpers/edits_helper.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
+# rubocop:disable ModuleLength
+
 module EditsHelper
+  include ApplicationHelper
   include EnlistmentsHelper
   include EditsModalHelper
 
@@ -95,9 +98,11 @@ module EditsHelper
   end
 
   def edit_enlistment_branch_info(edit)
-    if @parent.is_a?(Project) && edit.target.is_a?(Enlistment) && edit.is_a?(CreateEdit)
-      enlistment_branch_name_html_snippet(edit.target)
-    safe_text(end.to_s)
+    safe_text(
+      if @parent.is_a?(Project) && edit.target.is_a?(Enlistment) && edit.is_a?(CreateEdit)
+        enlistment_branch_name_html_snippet(edit.target)
+      end.to_s
+    )
   end
 
   def edit_explanation_link(edit)
@@ -126,3 +131,5 @@ module EditsHelper
     t('edits.explanation_rsssubscription', url: edit.target.rss_feed.url)
   end
 end
+
+# rubocop:enable ModuleLength

--- a/app/helpers/edits_helper.rb
+++ b/app/helpers/edits_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable ModuleLength
+# rubocop:disable Metrics/ModuleLength
 
 module EditsHelper
   include ApplicationHelper
@@ -132,4 +132,4 @@ module EditsHelper
   end
 end
 
-# rubocop:enable ModuleLength
+# rubocop:enable Metrics/ModuleLength

--- a/app/helpers/edits_helper.rb
+++ b/app/helpers/edits_helper.rb
@@ -97,7 +97,7 @@ module EditsHelper
   def edit_enlistment_branch_info(edit)
     if @parent.is_a?(Project) && edit.target.is_a?(Enlistment) && edit.is_a?(CreateEdit)
       enlistment_branch_name_html_snippet(edit.target)
-    end.to_s.html_safe
+    safe_text(end.to_s)
   end
 
   def edit_explanation_link(edit)

--- a/app/helpers/edits_helper.rb
+++ b/app/helpers/edits_helper.rb
@@ -19,8 +19,8 @@ module EditsHelper
     edit.undone? ? t('edits.undone') : nil
   end
 
-  def edit_show_subject(edit)
-    html_escape(edit_subject(edit)) + ' ' + edit_enlistment_branch_info(edit)
+  def edit_show_subject(edit, parent)
+    html_escape(edit_subject(edit, parent)) + ' ' + edit_enlistment_branch_info(edit, parent)
   end
 
   def get_edit_summary(edit)
@@ -33,9 +33,9 @@ module EditsHelper
     params[:organization_id].present? || edit.key == 'organization_id' || edit.key == 'org_type'
   end
 
-  def edit_subject(edit)
-    project_term = if @parent.is_a?(Project) || @parent.is_a?(Organization)
-                     "#{@parent.class} '#{@parent.name}': "
+  def edit_subject(edit, parent)
+    project_term = if parent.is_a?(Project) || parent.is_a?(Organization)
+                     "#{parent.class} '#{parent.name}': "
                    else
                      ''
                    end
@@ -97,9 +97,9 @@ module EditsHelper
     t('edits.explanation_enlistment', url: edit.target.code_location.url)
   end
 
-  def edit_enlistment_branch_info(edit)
+  def edit_enlistment_branch_info(edit, parent)
     safe_text(
-      if @parent.is_a?(Project) && edit.target.is_a?(Enlistment) && edit.is_a?(CreateEdit)
+      if parent.is_a?(Project) && edit.target.is_a?(Enlistment) && edit.is_a?(CreateEdit)
         enlistment_branch_name_html_snippet(edit.target)
       end.to_s
     )

--- a/app/helpers/edits_modal_helper.rb
+++ b/app/helpers/edits_modal_helper.rb
@@ -7,9 +7,9 @@ module EditsModalHelper
     expander(get_edit_value(edit) || edit.value, 300, 340)
   end
 
-  def show_edit_path(edit)
-    path = "#{@parent.class.name.downcase}_edit_path".to_sym
-    send(path, @parent, edit) if respond_to?(path)
+  def show_edit_path(edit, parent)
+    path = "#{parent.class.name.downcase}_edit_path".to_sym
+    send(path, parent, edit) if respond_to?(path)
   end
 
   def get_edit_value(edit)

--- a/app/helpers/enlistments_helper.rb
+++ b/app/helpers/enlistments_helper.rb
@@ -18,8 +18,8 @@ module EnlistmentsHelper
     content_tag :span, "Branch: #{enlistment.code_location.branch}", class: 'edit_enlist_branch_name'
   end
 
-  def sidekiq_work_in_progress?
-    key = Setting.get_project_enlistment_key(@project.id)
+  def sidekiq_work_in_progress?(project)
+    key = Setting.get_project_enlistment_key(project.id)
     Setting.get_value(key).try(:present?)
   end
 

--- a/app/helpers/explore_helper.rb
+++ b/app/helpers/explore_helper.rb
@@ -15,8 +15,8 @@ module ExploreHelper
     end
   end
 
-  def cache_projects_explore_page
-    if @language.blank?
+  def cache_projects_explore_page(language)
+    if language.blank?
       Rails.cache.fetch('projects_explore_page', expires_in: 1.hour) do
         render 'projects'
       end

--- a/app/helpers/factoids_helper.rb
+++ b/app/helpers/factoids_helper.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module FactoidsHelper
-  def get_factoid_display(fact)
-    text, type, url = factiod_info(fact)
+  def get_factoid_display(fact, project, analysis)
+    text, type, url = factiod_info(fact, project, analysis)
     haml_tag :span, class: type.to_s do
       haml_tag :a, href: url do
         concat text
@@ -12,16 +12,16 @@ module FactoidsHelper
 
   private
 
-  def get_factoid_type(fact)
+  def get_factoid_type(fact, analysis)
     match = "Factoid#{fact.to_s.capitalize}"
-    fact = @analysis.factoids.select { |f| f.type.starts_with?(match) }
+    fact = analysis.factoids.select { |f| f.type.starts_with?(match) }
     fact.empty? ? nil : fact.first
   end
 
-  def factiod_info(fact)
-    factoid = get_factoid_type(fact)
+  def factiod_info(fact, project, analysis)
+    factoid = get_factoid_type(fact, analysis)
     if factoid
-      [factoid.inline, factoid.category, project_factoids_path(@project, anchor: factoid.type)]
+      [factoid.inline, factoid.category, project_factoids_path(project, anchor: factoid.type)]
     else
       factoid_no_factoid_info(fact)
     end

--- a/app/helpers/forums_helper.rb
+++ b/app/helpers/forums_helper.rb
@@ -8,7 +8,7 @@ module ForumsHelper
       [nil,             t(:topic)],
       [:new_topic,      t(:new_topic), new_forum_topic_path(forum)],
       [:forum,          forum.name, forum_path(forum)]
-    ] if @forum
+    ] if forum
 
     menus << [
       [nil,             t(:post)],

--- a/app/helpers/forums_helper.rb
+++ b/app/helpers/forums_helper.rb
@@ -2,12 +2,12 @@
 
 module ForumsHelper
   # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Style/MultilineIfModifier
-  def forums_sidebar
+  def forums_sidebar(forum)
     menus = []
     menus << [
       [nil,             t(:topic)],
-      [:new_topic,      t(:new_topic), new_forum_topic_path(@forum)],
-      [:forum,          @forum.name, forum_path(@forum)]
+      [:new_topic,      t(:new_topic), new_forum_topic_path(forum)],
+      [:forum,          forum.name, forum_path(forum)]
     ] if @forum
 
     menus << [
@@ -19,7 +19,7 @@ module ForumsHelper
     menus << [
       [nil,             t(:admin)],
       [:new,            t(:new_forum), new_forum_path]
-    ] if current_user_is_admin? && !@forum
+    ] if current_user_is_admin? && !forum
 
     menus
   end

--- a/app/helpers/job_api_helper.rb
+++ b/app/helpers/job_api_helper.rb
@@ -21,7 +21,7 @@ module JobApiHelper
   def slave_host(slave_id)
     return unless slave_id
 
-    "on #{link_to Slave.find(slave_id).hostname, '#'}".html_safe
+    safe_text("on #{link_to Slave.find(slave_id).hostname, '#'}")
   end
 
   def job_progress(job)

--- a/app/helpers/license_helper.rb
+++ b/app/helpers/license_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop: disable HelperInstanceVariable
+
 module LicenseHelper
   def categorize_permission(permission)
     permission_exists = permission['license_permission_id'].present?
@@ -75,3 +77,5 @@ module LicenseHelper
     end
   end
 end
+
+# rubocop: enable HelperInstanceVariable

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module MarkdownHelper
+  include ApplicationHelper
+
   def markdown_format(text)
     options = { filter_html: true,
                 hard_wrap: true,

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -7,7 +7,7 @@ module MarkdownHelper
                 link_attributes: { rel: 'nofollow', target: '_blank' } }
     renderer = Redcarpet::Render::HTML.new(options)
     markdown = Redcarpet::Markdown.new(renderer, autolink: true, tables: true)
-    markdown.render(text).html_safe
+    safe_text(markdown.render(text))
   rescue StandardError
     Rails.logger.error "Redcarpet failed to convert:\n#{text}."
     text.to_s

--- a/app/helpers/page_context_helper.rb
+++ b/app/helpers/page_context_helper.rb
@@ -33,8 +33,8 @@ module PageContextHelper
                      page_header: 'projects/show/header')
   end
 
-  def forum_context
-    set_page_context(footer_menu_list: forums_sidebar)
+  def forum_context(forum)
+    set_page_context(footer_menu_list: forums_sidebar(forum))
   end
 
   def tool_context

--- a/app/helpers/page_context_helper.rb
+++ b/app/helpers/page_context_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop: disable HelperInstanceVariable
+
 module PageContextHelper
   include ForumsHelper
 
@@ -62,3 +64,5 @@ module PageContextHelper
     page_context.reverse_merge!(options)
   end
 end
+
+# rubocop: enable HelperInstanceVariable

--- a/app/helpers/project_vulnerability_reports_helper.rb
+++ b/app/helpers/project_vulnerability_reports_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop: disable HelperInstanceVariable
+
 module ProjectVulnerabilityReportsHelper
   def pointer(pvr, pvs = false)
     if pvs
@@ -37,3 +39,5 @@ module ProjectVulnerabilityReportsHelper
     @max_score ||= ProjectVulnerabilityReport.max_score
   end
 end
+
+# rubocop: enable HelperInstanceVariable

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -21,8 +21,8 @@ module ProjectsHelper
     end
   end
 
-  def project_compare_button(project, label = project.name)
-    selected = (@session_projects || []).include?(project)
+  def project_compare_button(project, session_projects, label = project.name)
+    selected = (session_projects || []).include?(project)
     haml_tag :form, class: "sp_form styled form-inline #{'selected' if selected}",
                     style: 'min-width: 94px;', id: "sp_form_#{project.to_param}" do
       haml_tag :span, class: 'sp_label', title: label do
@@ -50,14 +50,14 @@ module ProjectsHelper
     end
   end
 
-  def project_managers_list
-    @project.active_managers.map { |m| link_to(html_escape(m.name), account_path(m)) }.to_sentence
+  def project_managers_list(project)
+    project.active_managers.map { |m| link_to(html_escape(m.name), account_path(m)) }.to_sentence
   end
 
-  def stack_name(account)
-    stacks ||= account.stacks.joins(:projects).where(projects: { id: @project })
+  def stack_name(project, account)
+    stacks ||= account.stacks.joins(:projects).where(projects: { id: project })
     stacks.map do |stack|
-      name = stack.decorate.name(account, @project)
+      name = stack.decorate.name(account, project)
       link_to "#{name}#{' Stack' unless name =~ /stack/i}", stack_path(stack)
     end.join(', ')
   end
@@ -73,19 +73,19 @@ module ProjectsHelper
     end
   end
 
-  def show_badges
+  def show_badges(project)
     content_tag :div, class: 'badges' do
-      @project.badges_summary.map do |badge|
+      project.badges_summary.map do |badge|
         concat content_tag(:img, nil, src: badge.badge_url)
       end
     end
   end
 
-  def more_badges_link
-    return if @project.project_badges.active.count <= ProjectBadge::SUMMARY_LIMIT
+  def more_badges_link(project)
+    return if project.project_badges.active.count <= ProjectBadge::SUMMARY_LIMIT
 
     content_tag :div, class: 'more_badges clearfix' do
-      content_tag :p, link_to('more', project_project_badges_path(@project))
+      content_tag :p, link_to('more', project_project_badges_path(project))
     end
   end
 

--- a/app/helpers/site_features_helper.rb
+++ b/app/helpers/site_features_helper.rb
@@ -3,14 +3,14 @@
 module SiteFeaturesHelper
   # rubocop:disable Metrics/MethodLength
 
-  def features_hash
+  def features_hash(project)
     {
       'OpenHub' => [
         "you can subscribe to e-mail newsletters to receive update from the <a href='http://blog.openhub.net/'
          target='_blank'>Open Hub blog</a>",
         "data presented on the Open Hub is available through our
          <a href='https://github.com/blackducksoftware/ohloh_api#ohloh-api-documentation' target='_blank'>API</a>",
-        "you can embed <a href=#{project_widgets_path(project_id: @project.to_param)}
+        "you can embed <a href=#{project_widgets_path(project_id: project.to_param)}
          target='_self'>statistics from Open Hub</a> on your site",
         'by exploring contributors within projects, you can view details on every commit
          they have made to that project',
@@ -34,12 +34,13 @@ module SiteFeaturesHelper
     }.freeze
   end
 
-  def random_site_features
+  def random_site_features(project)
+    hash = features_hash(project)
     [].tap do |arr|
-      (features_hash.keys - ['OpenHub']).each do |key|
-        arr << features_hash[key].sample(2)
+      (hash.keys - ['OpenHub']).each do |key|
+        arr << hash[key].sample(2)
       end
-    end.flatten.zip(features_hash['OpenHub'].sample(2)).flatten
+    end.flatten.zip(hash['OpenHub'].sample(2)).flatten
   end
   # rubocop:enable Metrics/MethodLength
 end

--- a/app/helpers/stacks_helper.rb
+++ b/app/helpers/stacks_helper.rb
@@ -10,7 +10,7 @@ module StacksHelper
   def stack_similar_project_list(projects)
     projects.collect do |proj|
       link_to(html_escape(proj.name), project_path(proj), title: html_escape(proj.name))
-    end.join(', ').html_safe
+    end.safe_text(join(', '))
   end
 
   def stack_country_flag(code)

--- a/app/helpers/stacks_helper.rb
+++ b/app/helpers/stacks_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module StacksHelper
+  include ApplicationHelper
+
   def stack_edit_in_place
     haml_tag :a, class: 'rest_in_place_helper' do
       concat I18n.t('stacks.edit_in_place')
@@ -8,9 +10,10 @@ module StacksHelper
   end
 
   def stack_similar_project_list(projects)
-    projects.collect do |proj|
+    str = projects.collect do |proj|
       link_to(html_escape(proj.name), project_path(proj), title: html_escape(proj.name))
-    end.safe_text(join(', '))
+    end.join(', ')
+    safe_text(str)
   end
 
   def stack_country_flag(code)

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -9,7 +9,7 @@ module TagsHelper
     tag_list[0..(max_tags - 1)].collect do |tag|
       tag = tag.fix_encoding_if_invalid
       link_to html_escape(tag), tags_path(names: tag), class: 'tag', itemprop: 'keywords'
-    end.join(' ').html_safe
+    end.safe_text(join(' '))
   end
 
   def tags_left(count)

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -1,15 +1,18 @@
 # frozen_string_literal: true
 
 module TagsHelper
+  include ApplicationHelper
+
   def tag_icon_link(project)
     link_to_if project.edit_authorized?, t('.tags'), project_tags_path(project), class: 'noborder'
   end
 
   def tag_links(tag_list, max_tags = tag_list.length)
-    tag_list[0..(max_tags - 1)].collect do |tag|
+    str = tag_list[0..(max_tags - 1)].collect do |tag|
       tag = tag.fix_encoding_if_invalid
       link_to html_escape(tag), tags_path(names: tag), class: 'tag', itemprop: 'keywords'
-    end.safe_text(join(' '))
+    end.join(' ')
+    safe_text(str)
   end
 
   def tags_left(count)

--- a/app/helpers/vulnerabilities_helper.rb
+++ b/app/helpers/vulnerabilities_helper.rb
@@ -67,7 +67,7 @@ module VulnerabilitiesHelper
                           date: options[0])
     end
     html += hidden_field_tag('vulnerability_filter_period', filter_period_param, class: 'vulnerability_main_filter')
-    html.html_safe
+    safe_text(html)
   end
 
   def releaase_timespan_options

--- a/app/helpers/vulnerabilities_helper.rb
+++ b/app/helpers/vulnerabilities_helper.rb
@@ -43,24 +43,24 @@ module VulnerabilitiesHelper
     [Release.new(id: '', version: t('.vulnerabilities.filter.no_versions_available'))]
   end
 
-  def disabled_severities
-    return [] unless @release
+  def disabled_severities(release)
+    return [] unless release
 
-    (severities + [EMPTY_SEVERITY]).select { |s| @release.vulnerabilities.send(s).empty? }
+    (severities + [EMPTY_SEVERITY]).select { |s| release.vulnerabilities.send(s).empty? }
   end
 
-  def options_for_severities_filter
+  def options_for_severities_filter(release)
     options_for_select(severities.collect { |s| [s.capitalize, s] } + [['Unknown', EMPTY_SEVERITY]],
-                       selected: filter_severity_param, disabled: disabled_severities)
+                       selected: filter_severity_param, disabled: disabled_severities(release))
   end
 
   def severities
     Vulnerability.severities.keys
   end
 
-  def release_timespan_widget
+  def release_timespan_widget(default_timespan, security_set)
     html = ''
-    timespan = releaase_timespan_options
+    timespan = releaase_timespan_options(default_timespan, security_set)
     timespan.each do |label, options|
       html += content_tag(:div, label,
                           class: "btn btn-info btn-mini release_timespan #{(options[1..2] || []).join(' ')}".strip,
@@ -70,22 +70,22 @@ module VulnerabilitiesHelper
     safe_text(html)
   end
 
-  def releaase_timespan_options
+  def releaase_timespan_options(default_timespan, security_set)
     timespan = {}
     Release::TIMESPAN.each { |label, values| timespan[label] = values.dup }
-    disable_timespan(timespan)
-    set_default_timespan(timespan)
+    disable_timespan(timespan, security_set)
+    set_default_timespan(timespan, default_timespan)
   end
 
-  def set_default_timespan(timespan)
-    timespan.tap { |ts| ts[@default_timespan].push 'selected' }
+  def set_default_timespan(timespan, default_timespan)
+    timespan.tap { |ts| ts[default_timespan].push 'selected' }
   end
 
-  def disable_timespan(timespan)
+  def disable_timespan(timespan, security_set)
     timespan.each do |_label, values|
       next if values[0].blank?
 
-      values.push(@best_security_set.releases.select_within_years(values[0]).blank? ? 'disabled' : '')
+      values.push(security_set.releases.select_within_years(values[0]).blank? ? 'disabled' : '')
     end
   end
 

--- a/app/lib/acts_as_editable/acts_as_editable.rb
+++ b/app/lib/acts_as_editable/acts_as_editable.rb
@@ -86,4 +86,6 @@ module ActsAsEditable
   end
 end
 
-ActiveRecord::Base.send :include, ActsAsEditable
+ActiveRecord::Base.class_eval do
+  include ActsAsEditable
+end

--- a/app/lib/acts_as_protected/acts_as_protected.rb
+++ b/app/lib/acts_as_protected/acts_as_protected.rb
@@ -52,4 +52,6 @@ module ActsAsProtected
   end
 end
 
-ActiveRecord::Base.send :include, ActsAsProtected
+ActiveRecord::Base.class_eval do
+  include ActsAsProtected
+end

--- a/app/lib/acts_as_taggable/acts_as_taggable.rb
+++ b/app/lib/acts_as_taggable/acts_as_taggable.rb
@@ -36,4 +36,6 @@ module ActsAsTaggable
   end
 end
 
-ActiveRecord::Base.send :include, ActsAsTaggable
+ActiveRecord::Base.class_eval do
+  include ActsAsTaggable
+end

--- a/app/lib/cherry/cherry.rb
+++ b/app/lib/cherry/cherry.rb
@@ -62,4 +62,6 @@ require_relative 'lib/decoratable'
 module Cherry
 end
 
-ActiveRecord::Base.send :include, Cherry::Decoratable
+ActiveRecord::Base.class_eval do
+  include Cherry::Decoratable
+end

--- a/app/lib/filter_by/filter_by.rb
+++ b/app/lib/filter_by/filter_by.rb
@@ -22,4 +22,6 @@ module FilterBy
   end
 end
 
-ActiveRecord::Base.send :extend, FilterBy
+ActiveRecord::Base.class_eval do
+  extend FilterBy
+end

--- a/app/lib/tsearch/tsearch.rb
+++ b/app/lib/tsearch/tsearch.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable SkipsModelValidations
+
 module Tsearch
   extend ActiveSupport::Concern
 
@@ -75,3 +77,5 @@ module Tsearch
   end
   # rubocop:enable Metrics/BlockLength
 end
+
+# rubocop:enable SkipsModelValidations

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable SkipsModelValidations
+
 class Account < ActiveRecord::Base
   include AffiliationValidation
   include AccountValidations
@@ -127,3 +129,6 @@ class Account < ActiveRecord::Base
     end
   end
 end
+
+# rubocop:enable SkipsModelValidations
+

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -131,4 +131,3 @@ class Account < ActiveRecord::Base
 end
 
 # rubocop:enable SkipsModelValidations
-

--- a/app/models/account/access.rb
+++ b/app/models/account/access.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable SkipsModelValidations
+
 class Account::Access < OhDelegator::Base
   delegate :level, to: :account
 
@@ -69,3 +71,5 @@ class Account::Access < OhDelegator::Base
     mobile_or_oauth_verified? && email_verified?
   end
 end
+
+# rubocop:enable SkipsModelValidations

--- a/app/models/account/hooks.rb
+++ b/app/models/account/hooks.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # rubocop:disable Metrics/ClassLength
+# rubocop:disable SkipsModelValidations
 
 class Account::Hooks
   def before_validation(account)
@@ -140,3 +141,4 @@ class Account::Hooks
   end
 end
 # rubocop:enable Metrics/ClassLength
+# rubocop:enable SkipsModelValidations

--- a/app/models/account/position_core.rb
+++ b/app/models/account/position_core.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop: disable InverseOf
+
 class Account::PositionCore < OhDelegator::Base
   parent_scope do
     has_many :positions, lambda {
@@ -114,3 +116,5 @@ class Account::PositionCore < OhDelegator::Base
                                                 :name, :account, :contribution, :affiliation)
   end
 end
+
+# rubocop: enable InverseOf

--- a/app/models/account/stack_core.rb
+++ b/app/models/account/stack_core.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop: disable InverseOf
+
 class Account::StackCore < OhDelegator::Base
   parent_scope do
     has_many :stacks, -> { order(updated_at: :desc).where(deleted_at: nil) }
@@ -10,3 +12,5 @@ class Account::StackCore < OhDelegator::Base
     @default ||= stacks[0]
   end
 end
+
+# rubocop: enable InverseOf

--- a/app/models/account/subscription.rb
+++ b/app/models/account/subscription.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable SkipsModelValidations
+
 class Account::Subscription
   attr_reader :account
 
@@ -20,3 +22,5 @@ class Account::Subscription
     CGI.unescape(Ohloh::Cipher.encrypt(account.id.to_s))
   end
 end
+
+# rubocop:enable SkipsModelValidations

--- a/app/models/action.rb
+++ b/app/models/action.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop: disable InverseOf
+
 class Action < ActiveRecord::Base
   attr_reader :payload_required
 
@@ -55,3 +57,5 @@ class Action < ActiveRecord::Base
     errors.add :claim, I18n.t('actions.account_never_contributed')
   end
 end
+
+# rubocop: enable InverseOf

--- a/app/models/alias.rb
+++ b/app/models/alias.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable HasManyOrHasOneDependent
+
 class Alias < ActiveRecord::Base
   include AliasScopes
   belongs_to :project
@@ -105,3 +107,5 @@ class Alias < ActiveRecord::Base
     ContributorFact.find_by(name_id: commit_name_id, analysis_id: project.best_analysis_id)
   end
 end
+
+# rubocop:enable HasManyOrHasOneDependent

--- a/app/models/alias.rb
+++ b/app/models/alias.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # rubocop:disable HasManyOrHasOneDependent
+# rubocop:disable InverseOf
 
 class Alias < ActiveRecord::Base
   include AliasScopes
@@ -108,4 +109,5 @@ class Alias < ActiveRecord::Base
   end
 end
 
+# rubocop:enable InverseOf
 # rubocop:enable HasManyOrHasOneDependent

--- a/app/models/analysis.rb
+++ b/app/models/analysis.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # rubocop:disable HasManyOrHasOneDependent
+# rubocop:disable InverseOf
 
 class Analysis < ActiveRecord::Base
   include Analysis::Report
@@ -122,4 +123,5 @@ class Analysis < ActiveRecord::Base
   end
 end
 
+# rubocop:enable InverseOf
 # rubocop:enable HasManyOrHasOneDependent

--- a/app/models/analysis.rb
+++ b/app/models/analysis.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable HasManyOrHasOneDependent
+
 class Analysis < ActiveRecord::Base
   include Analysis::Report
   AVG_SALARY = 55_000
@@ -119,3 +121,5 @@ class Analysis < ActiveRecord::Base
     end
   end
 end
+
+# rubocop:enable HasManyOrHasOneDependent

--- a/app/models/analysis_alias.rb
+++ b/app/models/analysis_alias.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop: disable InverseOf
+
 class AnalysisAlias < FisBase
   belongs_to :analysis
   belongs_to :commit_name, class_name: 'Name', foreign_key: :commit_name_id
@@ -18,3 +20,5 @@ class AnalysisAlias < FisBase
       .pluck(:commit_name_id)
   }
 end
+
+# rubocop: enable InverseOf

--- a/app/models/analysis_sloc_set.rb
+++ b/app/models/analysis_sloc_set.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable HasManyOrHasOneDependent
+
 class AnalysisSlocSet < FisBase
   belongs_to :analysis
   belongs_to :sloc_set
@@ -41,3 +43,5 @@ class AnalysisSlocSet < FisBase
     end
   end
 end
+
+# rubocop:enable HasManyOrHasOneDependent

--- a/app/models/analysis_sloc_set.rb
+++ b/app/models/analysis_sloc_set.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # rubocop:disable HasManyOrHasOneDependent
+# rubocop:disable InverseOf
 
 class AnalysisSlocSet < FisBase
   belongs_to :analysis
@@ -44,4 +45,5 @@ class AnalysisSlocSet < FisBase
   end
 end
 
+# rubocop:enable InverseOf
 # rubocop:enable HasManyOrHasOneDependent

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable SkipsModelValidations
+
 class ApiKey < ActiveRecord::Base
   DEFAULT_DAILY_LIMIT = 1000
   STATUS_OK = 0
@@ -76,3 +78,5 @@ class ApiKey < ActiveRecord::Base
             status: status)
   end
 end
+
+# rubocop:enable SkipsModelValidations

--- a/app/models/code_set.rb
+++ b/app/models/code_set.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # rubocop:disable HasManyOrHasOneDependent
+# rubocop:disable InverseOf
 
 class CodeSet < FisBase
   belongs_to :best_sloc_set, foreign_key: :best_sloc_set_id, class_name: 'SlocSet'
@@ -73,4 +74,5 @@ class CodeSet < FisBase
   # .... to here
 end
 
+# rubocop:enable InverseOf
 # rubocop:enable HasManyOrHasOneDependent

--- a/app/models/code_set.rb
+++ b/app/models/code_set.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable HasManyOrHasOneDependent
+
 class CodeSet < FisBase
   belongs_to :best_sloc_set, foreign_key: :best_sloc_set_id, class_name: 'SlocSet'
   has_many :commits, -> { order(:position) }, dependent: :destroy
@@ -70,3 +72,5 @@ class CodeSet < FisBase
   end
   # .... to here
 end
+
+# rubocop:enable HasManyOrHasOneDependent

--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable HasManyOrHasOneDependent
+
 class Commit < FisBase
   belongs_to :code_set
   belongs_to :name
@@ -71,3 +73,5 @@ class Commit < FisBase
     short ? sha1.to_s.truncate(8, omission: '') : sha1
   end
 end
+
+# rubocop:enable HasManyOrHasOneDependent

--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # rubocop:disable HasManyOrHasOneDependent
+# rubocop:disable InverseOf
 
 class Commit < FisBase
   belongs_to :code_set
@@ -74,4 +75,5 @@ class Commit < FisBase
   end
 end
 
+# rubocop:enable InverseOf
 # rubocop:enable HasManyOrHasOneDependent

--- a/app/models/concerns/account_associations.rb
+++ b/app/models/concerns/account_associations.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # rubocop:disable HasManyOrHasOneDependent
+# rubocop:disable InverseOf
 
 module AccountAssociations
   extend ActiveSupport::Concern
@@ -32,4 +33,5 @@ module AccountAssociations
   end
 end
 
+# rubocop:enable InverseOf
 # rubocop:enable HasManyOrHasOneDependent

--- a/app/models/concerns/account_associations.rb
+++ b/app/models/concerns/account_associations.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable HasManyOrHasOneDependent
+
 module AccountAssociations
   extend ActiveSupport::Concern
 
@@ -29,3 +31,5 @@ module AccountAssociations
     has_one :reverification_tracker, dependent: :destroy
   end
 end
+
+# rubocop:enable HasManyOrHasOneDependent

--- a/app/models/concerns/on_behalf.rb
+++ b/app/models/concerns/on_behalf.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop: disable InverseOf
+
 module OnBehalf
   extend ActiveSupport::Concern
 
@@ -43,3 +45,5 @@ module OnBehalf
     errors.add(:send_limit, err_msg) if invites_sent_from_this_account >= OnBehalf::MAX_SENT
   end
 end
+
+# rubocop: enable InverseOf

--- a/app/models/concerns/organization_jobs.rb
+++ b/app/models/concerns/organization_jobs.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable SkipsModelValidations
+
 module OrganizationJobs
   extend ActiveSupport::Concern
 
@@ -29,3 +31,5 @@ module OrganizationJobs
     job
   end
 end
+
+# rubocop:enable SkipsModelValidations

--- a/app/models/concerns/project_associations.rb
+++ b/app/models/concerns/project_associations.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # rubocop:disable HasManyOrHasOneDependent
+# rubocop:disable InverseOf
 
 module ProjectAssociations
   extend ActiveSupport::Concern
@@ -92,4 +93,5 @@ module ProjectAssociations
   end
 end
 
+# rubocop:enable InverseOf
 # rubocop:enable HasManyOrHasOneDependent

--- a/app/models/concerns/project_associations.rb
+++ b/app/models/concerns/project_associations.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable HasManyOrHasOneDependent
+
 module ProjectAssociations
   extend ActiveSupport::Concern
 
@@ -89,3 +91,5 @@ module ProjectAssociations
     end
   end
 end
+
+# rubocop:enable HasManyOrHasOneDependent

--- a/app/models/concerns/project_jobs.rb
+++ b/app/models/concerns/project_jobs.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable SkipsModelValidations
+
 module ProjectJobs
   extend ActiveSupport::Concern
   ACTIVITY_LEVEL = { na: 0, new: 10, inactive: 20, very_low: 30, low: 40,
@@ -100,3 +102,5 @@ module ProjectJobs
     sloc_sets_out_of_date
   end
 end
+
+# rubocop:enable SkipsModelValidations

--- a/app/models/contribution.rb
+++ b/app/models/contribution.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop: disable InverseOf
+
 class Contribution < ActiveRecord::Base
   SORT_OPTIONS = %i[name kudo_position commits twelve_month_commits
                     language latest_commit newest oldest].freeze
@@ -106,3 +108,5 @@ class Contribution < ActiveRecord::Base
     end
   end
 end
+
+# rubocop: enable InverseOf

--- a/app/models/contribution.rb
+++ b/app/models/contribution.rb
@@ -10,7 +10,7 @@ class Contribution < ActiveRecord::Base
   belongs_to :person
   belongs_to :name_fact
   belongs_to :contributor_fact, foreign_key: 'name_fact_id'
-  has_many :invites
+  has_many :invites, dependent: :destroy
   has_many :kudos, ->(contribution) { joins(:name_fact).where(NameFact.arel_table[:id].eq(contribution.name_fact_id)) },
            primary_key: :project_id, foreign_key: :project_id
 

--- a/app/models/duplicate.rb
+++ b/app/models/duplicate.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable SkipsModelValidations
+
 class Duplicate < ActiveRecord::Base
   RESOLVES = %i[stack_entries kudos tags ratings reviews links aliases enlistments
                 positions project_experiences edits self].freeze
@@ -123,3 +125,5 @@ class Duplicate < ActiveRecord::Base
     update_attribute(:resolved, true)
   end
 end
+
+# rubocop:enable SkipsModelValidations

--- a/app/models/edit.rb
+++ b/app/models/edit.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop: disable InverseOf
+
 class Edit < ActiveRecord::Base
   belongs_to :account
   belongs_to :target, polymorphic: true
@@ -102,3 +104,5 @@ class Edit < ActiveRecord::Base
     !target.is_a?(Project) && target.respond_to?(:organization_id) ? target.organization_id : nil
   end
 end
+
+# rubocop: enable InverseOf

--- a/app/models/enlistment.rb
+++ b/app/models/enlistment.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable HasManyOrHasOneDependent
+
 class Enlistment < ActiveRecord::Base
   has_one :create_edit, as: :target
   has_many :project_badges
@@ -84,3 +86,5 @@ class Enlistment < ActiveRecord::Base
     CodeLocationSubscription.create(params)
   end
 end
+
+# rubocop:enable HasManyOrHasOneDependent

--- a/app/models/enlistment.rb
+++ b/app/models/enlistment.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # rubocop:disable HasManyOrHasOneDependent
+# rubocop:disable InverseOf
 
 class Enlistment < ActiveRecord::Base
   has_one :create_edit, as: :target
@@ -87,4 +88,5 @@ class Enlistment < ActiveRecord::Base
   end
 end
 
+# rubocop:enable InverseOf
 # rubocop:enable HasManyOrHasOneDependent

--- a/app/models/failure_group.rb
+++ b/app/models/failure_group.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable SkipsModelValidations
+
 class FailureGroup < ActiveRecord::Base
   has_many :jobs, -> { where(status: Job::STATUS_FAILED).with_exception }
   def decategorize
@@ -29,3 +31,5 @@ class FailureGroup < ActiveRecord::Base
     end
   end
 end
+
+# rubocop:enable SkipsModelValidations

--- a/app/models/failure_group.rb
+++ b/app/models/failure_group.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # rubocop:disable SkipsModelValidations
+# rubocop:disable InverseOf
 
 class FailureGroup < ActiveRecord::Base
   has_many :jobs, -> { where(status: Job::STATUS_FAILED).with_exception }
@@ -32,4 +33,5 @@ class FailureGroup < ActiveRecord::Base
   end
 end
 
+# rubocop:enable InverseOf
 # rubocop:enable SkipsModelValidations

--- a/app/models/forge.rb
+++ b/app/models/forge.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable HasManyOrHasOneDependent
+
 class Forge < ActiveRecord::Base
   has_many :repositories
   has_many :projects
@@ -20,3 +22,5 @@ class Forge < ActiveRecord::Base
     []
   end
 end
+
+# rubocop:enable HasManyOrHasOneDependent

--- a/app/models/forge/base.rb
+++ b/app/models/forge/base.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
+# rubocop:disable HasManyOrHasOneDependent
+
 class Forge::Base < ActiveRecord::Base
   self.table_name = 'forges'
   has_many :repositories, foreign_key: 'forge_id'
   has_many :projects, foreign_key: 'forge_id'
 end
+
+# rubocop:enable HasManyOrHasOneDependent

--- a/app/models/forge/base.rb
+++ b/app/models/forge/base.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # rubocop:disable HasManyOrHasOneDependent
+# rubocop:disable InverseOf
 
 class Forge::Base < ActiveRecord::Base
   self.table_name = 'forges'
@@ -8,4 +9,5 @@ class Forge::Base < ActiveRecord::Base
   has_many :projects, foreign_key: 'forge_id'
 end
 
+# rubocop:enable InverseOf
 # rubocop:enable HasManyOrHasOneDependent

--- a/app/models/forum.rb
+++ b/app/models/forum.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop: disable InverseOf
+
 class Forum < ActiveRecord::Base
   validates :name, presence: true
   validates :position, numericality: { only_integer: true }, allow_blank: true
@@ -8,3 +10,5 @@ class Forum < ActiveRecord::Base
   has_many :topics, -> { order('sticky desc, updated_at desc') }, dependent: :destroy
   has_many :posts, through: :topics
 end
+
+# rubocop: enable InverseOf

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable HasManyOrHasOneDependent
+
 class Job < ActiveRecord::Base
   belongs_to :project
   belongs_to :slave
@@ -73,3 +75,5 @@ class Job < ActiveRecord::Base
     end
   end
 end
+
+# rubocop:enable HasManyOrHasOneDependent

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -2,6 +2,7 @@
 
 # rubocop:disable HasManyOrHasOneDependent
 # rubocop:disable SkipsModelValidations
+# rubocop:disable InverseOf
 
 class Job < ActiveRecord::Base
   belongs_to :project
@@ -77,5 +78,6 @@ class Job < ActiveRecord::Base
   end
 end
 
+# rubocop:enable InverseOf
 # rubocop:enable SkipsModelValidations
 # rubocop:enable HasManyOrHasOneDependent

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # rubocop:disable HasManyOrHasOneDependent
+# rubocop:disable SkipsModelValidations
 
 class Job < ActiveRecord::Base
   belongs_to :project
@@ -76,4 +77,5 @@ class Job < ActiveRecord::Base
   end
 end
 
+# rubocop:enable SkipsModelValidations
 # rubocop:enable HasManyOrHasOneDependent

--- a/app/models/kudo.rb
+++ b/app/models/kudo.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable HasManyOrHasOneDependent
+
 class Kudo < ActiveRecord::Base
   belongs_to :sender, foreign_key: :sender_id, class_name: 'Account'
   belongs_to :account
@@ -80,3 +82,5 @@ class Kudo < ActiveRecord::Base
     AccountMailer.kudo_recipient(self).deliver_now
   end
 end
+
+# rubocop:enable HasManyOrHasOneDependent

--- a/app/models/kudo.rb
+++ b/app/models/kudo.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # rubocop:disable HasManyOrHasOneDependent
+# rubocop:disable InverseOf
 
 class Kudo < ActiveRecord::Base
   belongs_to :sender, foreign_key: :sender_id, class_name: 'Account'
@@ -83,4 +84,5 @@ class Kudo < ActiveRecord::Base
   end
 end
 
+# rubocop:enable InverseOf
 # rubocop:enable HasManyOrHasOneDependent

--- a/app/models/language_fact.rb
+++ b/app/models/language_fact.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop: disable InverseOf
+
 class LanguageFact < ActiveRecord::Base
   belongs_to :language
   belongs_to :all_month, primary_key: :month, foreign_key: :month
@@ -47,3 +49,5 @@ class LanguageFact < ActiveRecord::Base
     end
   end
 end
+
+# rubocop: enable InverseOf

--- a/app/models/license.rb
+++ b/app/models/license.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable HasManyOrHasOneDependent
+
 class License < ActiveRecord::Base
   validates :vanity_url, uniqueness: { case_sensitive: false }, length: { in: 2..50 },
                          default_param_format: true
@@ -76,3 +78,5 @@ class License < ActiveRecord::Base
     end
   end
 end
+
+# rubocop:enable HasManyOrHasOneDependent

--- a/app/models/license_permission.rb
+++ b/app/models/license_permission.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable HasManyOrHasOneDependent
+
 class LicensePermission < ActiveRecord::Base
   belongs_to :license_right
   has_one :license_license_permission
@@ -9,3 +11,5 @@ class LicensePermission < ActiveRecord::Base
 
   enum status: { 'Permitted': 0, 'Forbidden': 1, 'Required': 2 }
 end
+
+# rubocop:enable HasManyOrHasOneDependent

--- a/app/models/license_permission.rb
+++ b/app/models/license_permission.rb
@@ -7,5 +7,5 @@ class LicensePermission < ActiveRecord::Base
   delegate :license, to: :license_license_permission
   validates :license_right_id, presence: true
 
-  enum status: %i[Permitted Forbidden Required]
+  enum status: { 'Permitted': 0, 'Forbidden': 1, 'Required': 2 }
 end

--- a/app/models/logo.rb
+++ b/app/models/logo.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable HasManyOrHasOneDependent
+
 class Logo < Attachment
   FILE_SIZE_LIMIT = (1..500.kilobytes).freeze
 
@@ -66,3 +68,5 @@ class Logo < Attachment
     style.blank? ? '' : "_#{style}"
   end
 end
+
+# rubocop:enable HasManyOrHasOneDependent

--- a/app/models/manage.rb
+++ b/app/models/manage.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop: disable InverseOf
+
 class Manage < ActiveRecord::Base
   MAX_PROJECTS = 200
 
@@ -69,3 +71,5 @@ class Manage < ActiveRecord::Base
     true
   end
 end
+
+# rubocop: enable InverseOf

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable HasManyOrHasOneDependent
+
 class Name < ActiveRecord::Base
   has_many :name_facts
   has_many :people
@@ -10,3 +12,5 @@ class Name < ActiveRecord::Base
     end
   end
 end
+
+# rubocop:enable HasManyOrHasOneDependent

--- a/app/models/name_fact.rb
+++ b/app/models/name_fact.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop: disable InverseOf
+
 class NameFact < ActiveRecord::Base
   include Comparable
   serialize :commits_by_project
@@ -39,3 +41,5 @@ class NameFact < ActiveRecord::Base
     other.last_checkin <=> last_checkin
   end
 end
+
+# rubocop: enable InverseOf

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # rubocop:disable HasManyOrHasOneDependent
+# rubocop:disable InverseOf
 
 class Organization < ActiveRecord::Base
   include OrganizationSearchables
@@ -124,4 +125,5 @@ class Organization < ActiveRecord::Base
   end
 end
 
+# rubocop:enable InverseOf
 # rubocop:enable HasManyOrHasOneDependent

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable HasManyOrHasOneDependent
+
 class Organization < ActiveRecord::Base
   include OrganizationSearchables
   include OrganizationJobs
@@ -121,3 +123,5 @@ class Organization < ActiveRecord::Base
     schedule_analysis
   end
 end
+
+# rubocop:enable HasManyOrHasOneDependent

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -2,6 +2,7 @@
 
 # rubocop:disable HasManyOrHasOneDependent
 # rubocop:disable DynamicFindBy
+# rubocop:disable InverseOf
 
 class Person < ActiveRecord::Base
   self.primary_key = :id
@@ -129,5 +130,6 @@ class Person < ActiveRecord::Base
   end
 end
 
+# rubocop:enable InverseOf
 # rubocop:enable DynamicFindBy
 # rubocop:enable HasManyOrHasOneDependent

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable HasManyOrHasOneDependent
+
 class Person < ActiveRecord::Base
   self.primary_key = :id
   self.per_page = 10
@@ -125,3 +127,5 @@ class Person < ActiveRecord::Base
     name_id? && project_id?
   end
 end
+
+# rubocop:enable HasManyOrHasOneDependent

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # rubocop:disable HasManyOrHasOneDependent
+# rubocop:disable DynamicFindBy
 
 class Person < ActiveRecord::Base
   self.primary_key = :id
@@ -128,4 +129,5 @@ class Person < ActiveRecord::Base
   end
 end
 
+# rubocop:enable DynamicFindBy
 # rubocop:enable HasManyOrHasOneDependent

--- a/app/models/person/builder.rb
+++ b/app/models/person/builder.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # rubocop:disable SkipsModelValidations
+# rubocop:disable DynamicFindBy
 
 class Person::Builder
   class << self
@@ -74,4 +75,5 @@ class Person::Builder
   end
 end
 
+# rubocop:enable DynamicFindBy
 # rubocop:enable SkipsModelValidations

--- a/app/models/person/builder.rb
+++ b/app/models/person/builder.rb
@@ -75,4 +75,3 @@ class Person::Builder
 end
 
 # rubocop:enable SkipsModelValidations
-

--- a/app/models/person/builder.rb
+++ b/app/models/person/builder.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable SkipsModelValidations
+
 class Person::Builder
   class << self
     def rebuild_kudos
@@ -71,3 +73,6 @@ class Person::Builder
     end
   end
 end
+
+# rubocop:enable SkipsModelValidations
+

--- a/app/models/position.rb
+++ b/app/models/position.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable HasManyOrHasOneDependent
+
 class Position < ActiveRecord::Base
   include AffiliationValidation
   include Position::Validations
@@ -119,3 +121,5 @@ class Position < ActiveRecord::Base
     committer_name && project
   end
 end
+
+# rubocop:enable HasManyOrHasOneDependent

--- a/app/models/position.rb
+++ b/app/models/position.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # rubocop:disable HasManyOrHasOneDependent
+# rubocop:disable InverseOf
 
 class Position < ActiveRecord::Base
   include AffiliationValidation
@@ -122,4 +123,5 @@ class Position < ActiveRecord::Base
   end
 end
 
+# rubocop:enable InverseOf
 # rubocop:enable HasManyOrHasOneDependent

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
-# rubocop:disable HasManyOrHasOneDependent
-
 # rubocop:disable Metrics/ClassLength
+# rubocop:disable HasManyOrHasOneDependent
+# rubocop:disable InverseOf
+
 class Project < ActiveRecord::Base
   has_one :create_edit, as: :target
   acts_as_editable editable_attributes: %i[name vanity_url organization_id best_analysis_id
@@ -146,5 +147,7 @@ class Project < ActiveRecord::Base
     tags.each(&:recalc_weight!)
   end
 end
-# rubocop:enable Metrics/ClassLength
+
+# rubocop:enable InverseOf
 # rubocop:enable HasManyOrHasOneDependent
+# rubocop:enable Metrics/ClassLength

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable HasManyOrHasOneDependent
+
 # rubocop:disable Metrics/ClassLength
 class Project < ActiveRecord::Base
   has_one :create_edit, as: :target
@@ -145,3 +147,4 @@ class Project < ActiveRecord::Base
   end
 end
 # rubocop:enable Metrics/ClassLength
+# rubocop:enable HasManyOrHasOneDependent

--- a/app/models/project_badge.rb
+++ b/app/models/project_badge.rb
@@ -8,7 +8,7 @@ class ProjectBadge < ActiveRecord::Base
   validates :enlistment_id, presence: true,
                             uniqueness: { scope: [:type],
                                           message: I18n.t('.project_badges.repo_validation') }
-  enum status: %i[inactive active]
+  enum status: { inactive: 0, active: 1 }
 
   SUMMARY_LIMIT = 2
 

--- a/app/models/project_security_set.rb
+++ b/app/models/project_security_set.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable HasManyOrHasOneDependent
+
 class ProjectSecuritySet < ActiveRecord::Base
   has_many :releases
   belongs_to :project
@@ -38,3 +40,5 @@ class ProjectSecuritySet < ActiveRecord::Base
     self.class.find_by_sql(sql)
   end
 end
+
+# rubocop:enable HasManyOrHasOneDependent

--- a/app/models/rating.rb
+++ b/app/models/rating.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable SkipsModelValidations
+
 class Rating < ActiveRecord::Base
   belongs_to :account
   belongs_to :project
@@ -17,3 +19,5 @@ class Rating < ActiveRecord::Base
     project.update_attribute(:rating_average, project.ratings.average(:score))
   end
 end
+
+# rubocop:enable SkipsModelValidations

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -2,7 +2,8 @@
 
 class Release < ActiveRecord::Base
   belongs_to :project_security_set
-  has_and_belongs_to_many :vulnerabilities
+  has_many :releases_vulnerabilities
+  has_many :vulnerabilities, through: :releases_vulnerabilities
 
   scope :sort_by_release_date, ->(order = :desc) { order(released_on: order) }
   scope :select_within_years, lambda { |year|

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable HasManyOrHasOneDependent
+
 class Release < ActiveRecord::Base
   belongs_to :project_security_set
   has_many :releases_vulnerabilities
@@ -25,3 +27,5 @@ class Release < ActiveRecord::Base
     project_security_set.matching_releases(major_version_number)
   end
 end
+
+# rubocop:enable HasManyOrHasOneDependent

--- a/app/models/reverification_tracker.rb
+++ b/app/models/reverification_tracker.rb
@@ -7,8 +7,8 @@ class ReverificationTracker < ActiveRecord::Base
   NOTIFICATION3_DUE_DAYS = 28
   NOTIFICATION4_DUE_DAYS = 14
   belongs_to :account
-  enum status: %i[pending delivered soft_bounced complained]
-  enum phase: %i[initial marked_for_disable disabled final_warning]
+  enum status: { pending: 0, delivered: 1, soft_bounced: 2, complained: 3 }
+  enum phase: { initial: 0, marked_for_disable: 1, disabled: 2, final_warning: 3 }
 
   scope :soft_bounced_until_yesterday, lambda {
     soft_bounced.includes(:account).where('DATE(sent_at) < DATE(NOW())')

--- a/app/models/reverification_tracker.rb
+++ b/app/models/reverification_tracker.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable SkipsModelValidations
+
 class ReverificationTracker < ActiveRecord::Base
   MAX_ATTEMPTS = 3
   NOTIFICATION1_DUE_DAYS = 21
@@ -111,3 +113,5 @@ class ReverificationTracker < ActiveRecord::Base
     end
   end
 end
+
+# rubocop:enable SkipsModelValidations

--- a/app/models/rss_feed.rb
+++ b/app/models/rss_feed.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # rubocop:disable HasManyOrHasOneDependent
+# rubocop:disable SkipsModelValidations
 
 require 'feedjira'
 
@@ -64,4 +65,5 @@ class RssFeed < ActiveRecord::Base
   end
 end
 
+# rubocop:enable SkipsModelValidations
 # rubocop:enable HasManyOrHasOneDependent

--- a/app/models/rss_feed.rb
+++ b/app/models/rss_feed.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable HasManyOrHasOneDependent
+
 require 'feedjira'
 
 class RssFeed < ActiveRecord::Base
@@ -61,3 +63,5 @@ class RssFeed < ActiveRecord::Base
     end
   end
 end
+
+# rubocop:enable HasManyOrHasOneDependent

--- a/app/models/rss_subscription.rb
+++ b/app/models/rss_subscription.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable HasManyOrHasOneDependent
+
 class RssSubscription < ActiveRecord::Base
   belongs_to :project
   belongs_to :rss_feed
@@ -17,3 +19,5 @@ class RssSubscription < ActiveRecord::Base
     I18n.t('.rss_subscriptions.index.explain', url: rss_feed.url)
   end
 end
+
+# rubocop:enable HasManyOrHasOneDependent

--- a/app/models/rss_subscription.rb
+++ b/app/models/rss_subscription.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # rubocop:disable HasManyOrHasOneDependent
+# rubocop:disable InverseOf
 
 class RssSubscription < ActiveRecord::Base
   belongs_to :project
@@ -20,4 +21,5 @@ class RssSubscription < ActiveRecord::Base
   end
 end
 
+# rubocop:enable InverseOf
 # rubocop:enable HasManyOrHasOneDependent

--- a/app/models/slave.rb
+++ b/app/models/slave.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable HasManyOrHasOneDependent
+
 require 'open3'
 require 'socket'
 
@@ -41,3 +43,5 @@ class Slave < FisBase
     hostname == Socket.gethostname
   end
 end
+
+# rubocop:enable HasManyOrHasOneDependent

--- a/app/models/slave.rb
+++ b/app/models/slave.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # rubocop:disable HasManyOrHasOneDependent
+# rubocop:disable InverseOf
 
 require 'open3'
 require 'socket'
@@ -44,4 +45,5 @@ class Slave < FisBase
   end
 end
 
+# rubocop:enable InverseOf
 # rubocop:enable HasManyOrHasOneDependent

--- a/app/models/sloc_metric.rb
+++ b/app/models/sloc_metric.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop: disable InverseOf
+
 class SlocMetric < FisBase
   belongs_to :diff
   belongs_to :language
@@ -43,3 +45,5 @@ class SlocMetric < FisBase
     end
   end
 end
+
+# rubocop: enable InverseOf

--- a/app/models/sloc_set.rb
+++ b/app/models/sloc_set.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
+# rubocop:disable HasManyOrHasOneDependent
+
 class SlocSet < FisBase
   belongs_to :code_set
   has_many :commit_flags, -> { order(time: :desc) }
   has_many :analysis_sloc_sets
 end
+
+# rubocop:enable HasManyOrHasOneDependent

--- a/app/models/sloc_set.rb
+++ b/app/models/sloc_set.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # rubocop:disable HasManyOrHasOneDependent
+# rubocop:disable InverseOf
 
 class SlocSet < FisBase
   belongs_to :code_set
@@ -8,4 +9,5 @@ class SlocSet < FisBase
   has_many :analysis_sloc_sets
 end
 
+# rubocop:enable InverseOf
 # rubocop:enable HasManyOrHasOneDependent

--- a/app/models/stack.rb
+++ b/app/models/stack.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable HasManyOrHasOneDependent
 # rubocop:disable Metrics/ClassLength
 class Stack < ActiveRecord::Base
   SAMPLE_PROJECT_IDS = { lamp: [3141, 72, 4139, 28],
@@ -138,4 +139,5 @@ class Stack < ActiveRecord::Base
     [projects, Project.find_by_sql(sql)].flatten
   end
 end
+# rubocop:enable HasManyOrHasOneDependent
 # rubocop:enable Metrics/ClassLength

--- a/app/models/stack_entry.rb
+++ b/app/models/stack_entry.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable SkipsModelValidations
+
 class StackEntry < ActiveRecord::Base
   MAX_NOTE_LENGTH = 255
 
@@ -68,3 +70,5 @@ class StackEntry < ActiveRecord::Base
     stack.stack_ignores.for_project(project).destroy_all
   end
 end
+
+# rubocop:enable SkipsModelValidations

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # rubocop:disable HasManyOrHasOneDependent
+# rubocop:disable SkipsModelValidations
 
 class Tag < ActiveRecord::Base
   MAX_ALLOWED_PER_PROJECT = 20
@@ -44,4 +45,5 @@ class Tag < ActiveRecord::Base
   end
 end
 
+# rubocop:enable SkipsModelValidations
 # rubocop:enable HasManyOrHasOneDependent

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable HasManyOrHasOneDependent
+
 class Tag < ActiveRecord::Base
   MAX_ALLOWED_PER_PROJECT = 20
 
@@ -41,3 +43,5 @@ class Tag < ActiveRecord::Base
     update_attribute :taggings_count, Tagging.count_by_sql(sql)
   end
 end
+
+# rubocop:enable HasManyOrHasOneDependent

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop: disable InverseOf
+
 class Topic < ActiveRecord::Base
   validates :account, :title, :hits, presence: true
   validates :sticky, :hits, numericality: true
@@ -14,3 +16,5 @@ class Topic < ActiveRecord::Base
 
   scope :recent, -> { where(closed: false).order(replied_at: :desc).limit(10) }
 end
+
+# rubocop: enable InverseOf

--- a/app/models/vita.rb
+++ b/app/models/vita.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable HasManyOrHasOneDependent
+
 class Vita < ActiveRecord::Base
   self.table_name = 'vitae'
   belongs_to :account
@@ -18,3 +20,5 @@ class Vita < ActiveRecord::Base
     Logo.where(id: logo_ids.compact)
   end
 end
+
+# rubocop:enable HasManyOrHasOneDependent

--- a/app/models/vulnerability.rb
+++ b/app/models/vulnerability.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable HasManyOrHasOneDependent
+
 class Vulnerability < ActiveRecord::Base
   enum severity: { low: 0, medium: 1, high: 2 }
 
@@ -46,3 +48,5 @@ class Vulnerability < ActiveRecord::Base
     published_on.to_date <= year.to_i.years.ago.to_date
   end
 end
+
+# rubocop:enable HasManyOrHasOneDependent

--- a/app/models/vulnerability.rb
+++ b/app/models/vulnerability.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Vulnerability < ActiveRecord::Base
-  enum severity: %i[low medium high]
+  enum severity: { low: 0, medium: 1, high: 2 }
 
   has_and_belongs_to_many :releases, counter_cache: true
 

--- a/app/models/vulnerability.rb
+++ b/app/models/vulnerability.rb
@@ -3,7 +3,8 @@
 class Vulnerability < ActiveRecord::Base
   enum severity: { low: 0, medium: 1, high: 2 }
 
-  has_and_belongs_to_many :releases, counter_cache: true
+  has_many :releases_vulnerabilities
+  has_many :releases, through: :releases_vulnerabilities, counter_cache: true
 
   scope :sort_by, ->(col = 'cve_id', order = :desc) { order("#{col}": order) }
   scope :unknown_severity, -> { where('severity is null') }

--- a/app/views/abouts/tools.html.haml
+++ b/app/views/abouts/tools.html.haml
@@ -32,7 +32,7 @@
       %p= t('.font_size')
       %p.language-list-lineheight
         - @languages.each do |language|
-          = link_to language.nice_name, language_path(language), style: compute_style_for_language_tag(language)
+          = link_to language.nice_name, language_path(language), style: compute_style_for_language_tag(language, @languages_total_sum)
       %p= t('.view_stats_for_all_languages_html', href: link_to(t('.all_languages'), languages_path))
     .col-md-4
       %h3= t('.additional_info')

--- a/app/views/admin/dashboard/_overview.html.arb
+++ b/app/views/admin/dashboard/_overview.html.arb
@@ -40,9 +40,11 @@ columns do
     panel 'Deployment Details' do
       revision_file = File.open(Rails.root.join('REVISION').to_s)
       revision = revision_file.read.strip
-      para %(Currently deployed:
-            #{link_to(revision, "https://github.com/blackducksoftware/ohloh-ui/commit/#{revision}")}).html_safe
-      para %(Last Deployed: <b>#{time_ago_in_words(revision_file.mtime)}</b> ago).html_safe
+      para %(safe_text(
+              Currently deployed:
+              #{link_to(revision, "https://github.com/blackducksoftware/ohloh-ui/commit/#{revision}")}
+            ))
+      para %(safe_text(Last Deployed: <b>#{time_ago_in_words(revision_file.mtime)}</b> ago))
       revision_file.close
     rescue StandardError => e
       para e

--- a/app/views/commits/_commit.html.haml
+++ b/app/views/commits/_commit.html.haml
@@ -16,7 +16,7 @@
     - @commits.each do |commit|
       - commit_contributor = @commit_contributor || @commit_contributors.fetch(commit.name_id, []).first
       - next if commit_contributor.nil?
-      %tr{ class: highlight(commit.time) }
+      %tr{ class: highlight(@hightlight_from, commit.time) }
         %td= link_to h(commit.obfuscate_email(commit.comment).split("\n").first), project_commit_path(@project, commit)
         %td
           = avatar_for(commit_contributor.person)

--- a/app/views/edits/_edit.html.haml
+++ b/app/views/edits/_edit.html.haml
@@ -13,7 +13,7 @@
         %p.strong.nomargin{ class: edit_title_class(edit) }
           = link_to edit.id, show_edit_path(edit), class: 'show_edit_btn', remote: true,
                     data: { toggle: 'modal', target: '#edit-details.modal', keyboard: true }
-          %span - #{edit_show_subject(edit)}
+          %span - #{edit_show_subject(edit, @parent)}
         %p
           by
           = link_to edit.account.name, account_path(edit.account)

--- a/app/views/edits/_edit.html.haml
+++ b/app/views/edits/_edit.html.haml
@@ -11,7 +11,7 @@
         = avatar_for(edit.account)
       .inside
         %p.strong.nomargin{ class: edit_title_class(edit) }
-          = link_to edit.id, show_edit_path(edit), class: 'show_edit_btn', remote: true,
+          = link_to edit.id, show_edit_path(edit, @parent), class: 'show_edit_btn', remote: true,
                     data: { toggle: 'modal', target: '#edit-details.modal', keyboard: true }
           %span - #{edit_show_subject(edit, @parent)}
         %p

--- a/app/views/enlistments/index.html.haml
+++ b/app/views/enlistments/index.html.haml
@@ -9,7 +9,7 @@
   = project_analysis_timestamp(@project)
 .clearfix
 
-- if sidekiq_work_in_progress?
+- if sidekiq_work_in_progress?(@project)
   .alert.alert-info.alert-block
     %h5.alert-heading.nomargin= t('.currently_importing')
 

--- a/app/views/explore/projects.html.haml
+++ b/app/views/explore/projects.html.haml
@@ -4,4 +4,4 @@
 
 %h1.margin_top_15= t('.title')
 
-= cache_projects_explore_page
+= cache_projects_explore_page(@language)

--- a/app/views/projects/_project_index.html.haml
+++ b/app/views/projects/_project_index.html.haml
@@ -3,7 +3,7 @@
   %h2.title.pull-left= link_to project.name.truncate(70), project_path(project), title: project.name
   .pull-right
     .compare
-      - project_compare_button(project, t('.compare')) if defined?(compare) && compare
+      - project_compare_button(project, @session_projects, t('.compare')) if defined?(compare) && compare
     - if params[:action].to_s != 'check_forge'
       .i_use_this
         - project_iusethis_button(project) if defined?(i_use_this) && i_use_this

--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -44,8 +44,8 @@
       - if @project.project_badges.active.present?
         %section#project_badges
           %h4.title= link_to t('project_badges.index.title'), project_project_badges_path(@project)
-          = show_badges
-          = more_badges_link
+          = show_badges(@project)
+          = more_badges_link(@project)
 
   .col-md-4.nutshell_container
     .well

--- a/app/views/projects/show/_factoids.html.haml
+++ b/app/views/projects/show/_factoids.html.haml
@@ -21,18 +21,18 @@
                   languages_summary_project_analysis_path(@project, id: 'latest')
         %br
         with
-        - get_factoid_display :comments
+        - get_factoid_display :comments, @project, @analysis
   %li
     \...
     .indent
       has
-      - get_factoid_display :age
+      - get_factoid_display :age, @project, @analysis
       %br
       maintained by
-      - get_factoid_display :team
+      - get_factoid_display :team, @project, @analysis
       %br
       with
-      - get_factoid_display :activity
+      - get_factoid_display :activity, @project, @analysis
   - unless homepage
     %li
       \...

--- a/app/views/projects/show/_quick_reference.html.haml
+++ b/app/views/projects/show/_quick_reference.html.haml
@@ -46,6 +46,6 @@
     = link_to t('.managers'), project_managers_path(@project)
   .col-xs-7{ style: 'margin-bottom: .5em;' }
     - if @project.active_managers.present?
-      != project_managers_list
+      != project_managers_list(@project)
     - else
       = link_to t('.become_first', what: @project.name), new_project_manager_path(@project)

--- a/app/views/projects/show/_site_features.html.haml
+++ b/app/views/projects/show/_site_features.html.haml
@@ -1,7 +1,7 @@
 .well
   %h4= t('.did_you_know') + '...'
   %ul.unstyled
-    - random_site_features.each do |feature|
+    - random_site_features(@project).each do |feature|
       %li
         \...
         .indent

--- a/app/views/projects/users.html.haml
+++ b/app/views/projects/users.html.haml
@@ -22,7 +22,7 @@
           = link_to avatar_img_for(account.person), avatar_path(account.person)
           .avatar_name
             %h4.nomargin= link_to h(account.person.person_name), avatar_path(account.person)
-          .margin_left_50.small!= stack_name(account)
+          .margin_left_50.small!= stack_name(@project, account)
       .col-md-6
         %h6.soft.margin_top_0= t('.contributions')
         = render partial: '/projects/person_contribution', locals: { person: account.person }

--- a/app/views/vulnerabilities/_version_filter.html.haml
+++ b/app/views/vulnerabilities/_version_filter.html.haml
@@ -6,5 +6,5 @@
       class: 'ctrl vulnerability_filter'
 .vulnerability_filter_wrapper.vulnerability_filter_severity
   %span.title= t('.severity')
-  = select_tag 'vulnerability[filter][severity]', options_for_severities_filter,
+  = select_tag 'vulnerability[filter][severity]', options_for_severities_filter(@release),
       include_blank: 'All', class: 'ctrl vulnerability_filter', disabled: @minor_versions.blank?

--- a/app/views/vulnerabilities/index.html.haml
+++ b/app/views/vulnerabilities/index.html.haml
@@ -32,7 +32,7 @@
                           data: { releases: @release_history.to_json }, class: 'vulnerability_main_filter' }
           = select_tag 'vulnerability_filter_major_version', select_opts, html_release_opts
         .pull-right.btn-toolbar{ 'aria-label' => '...', :role => 'group', style: 'margin-top: 17px' }
-          = release_timespan_widget
+          = release_timespan_widget(@default_timespan, @best_security_set)
       .row
         .pull-right
           .h6= t('.click_and_zoom')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -186,7 +186,7 @@ Rails.application.routes.draw do
   get 'p/_project_graph', to: 'compares#projects_graph', as: :compare_graph_projects, defaults: { format: 'js' }
   get 'projects/:id/stacks', to: 'stacks#project_stacks', constraints: { format: /xml/ }
   get 'p/:id/stacks', to: 'stacks#project_stacks', as: :project_stacks, constraints: { format: /xml/ }
-  get 'p/:id/stacks', to: redirect('/p/%{id}/users'), constraints: { format: /html/ }
+  get 'p/:id/stacks', to: redirect('/p/%<id>/users'), constraints: { format: /html/ }
   get 'projects', to: 'projects#index', as: :project_xml_api, constraints: { format: /xml/ }
   get 'projects/:project_id/badge_js',      to: 'project_widgets#thin_badge', defaults: { format: 'js' }
   get 'projects/:project_id/badge.:format', to: 'project_widgets#thin_badge'

--- a/lib/tasks/check_broken_links.rake
+++ b/lib/tasks/check_broken_links.rake
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable SkipsModelValidations
+
 desc 'Checks broken active links in active projects'
 task check_broken_links: :environment do
   Link.joins(:project).where(deleted: false, projects: { deleted: false }).select(:id, :url).find_each do |link|
@@ -35,3 +37,5 @@ def get_response(url)
   request = Net::HTTP::Head.new(uri.request_uri)
   http.request(request)
 end
+
+# rubocop:enable SkipsModelValidations

--- a/lib/tasks/remove_duplicate_gnu_public_license.rake
+++ b/lib/tasks/remove_duplicate_gnu_public_license.rake
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable SkipsModelValidations
+
 desc 'Remove duplicate GNU General Public License records'
 task remove_duplicate_gnu_general_public_license: :environment do
   original_license = License.find(122) # GNU General Public License v3.0 only(gpl3)
@@ -22,3 +24,5 @@ task remove_duplicate_gnu_general_public_license: :environment do
   # Delete duplicate licenses
   ActiveRecord::Base.connection.execute("delete from licenses where id in (#{duplicate_license_ids.join(',')});")
 end
+
+# rubocop:enable SkipsModelValidations

--- a/lib/tasks/remove_duplicate_microsoft_public_license.rake
+++ b/lib/tasks/remove_duplicate_microsoft_public_license.rake
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable SkipsModelValidations
+
 desc 'Remove duplicate Microsoft Public License records'
 task remove_duplicate_microsoft_public_license: :environment do
   ProjectLicense.where(license_id: 357).update_all(license_id: 150)
@@ -11,3 +13,5 @@ task remove_duplicate_microsoft_public_license: :environment do
   license.editor_account = Account.hamster
   license.update(vanity_url: 'Microsoft_Public_License')
 end
+
+# rubocop:enable SkipsModelValidations

--- a/script/fix_updated_at_for_topics
+++ b/script/fix_updated_at_for_topics
@@ -1,6 +1,8 @@
 #! /usr/bin/env ruby
 # frozen_string_literal: true
 
+# rubocop:disable SkipsModelValidations
+
 require_relative '../config/environment'
 
 class FixUpdatedAtForTopic
@@ -16,3 +18,5 @@ class FixUpdatedAtForTopic
 end
 
 FixUpdatedAtForTopic.new.execute
+
+# rubocop:enable SkipsModelValidations

--- a/script/flag_insufficient_github_verified_accounts_as_spammer.rb
+++ b/script/flag_insufficient_github_verified_accounts_as_spammer.rb
@@ -1,6 +1,8 @@
 #! /usr/bin/env ruby
 # frozen_string_literal: true
 
+# rubocop:disable SkipsModelValidations
+
 require_relative '../config/environment'
 require 'logger'
 
@@ -66,3 +68,5 @@ class FlagInsufficientGithubVerifiedAccounts
 end
 
 FlagInsufficientGithubVerifiedAccounts.new.execute
+
+# rubocop:enable SkipsModelValidations

--- a/script/insert_new_failure_groups.rb
+++ b/script/insert_new_failure_groups.rb
@@ -5,7 +5,7 @@ raise 'RAILS_ENV is undefined' unless ENV['RAILS_ENV']
 
 require_relative '../config/environment'
 
-# rubocop:disable LineLength
+# rubocop:disable Metrics/LineLength
 ActiveRecord::Base.connection.execute("
 
 INSERT INTO failure_groups(
@@ -28,5 +28,5 @@ INSERT INTO failure_groups(
     ('Investigate: Ambiguous argument - unknown revision', '%fatal: ambiguous argument%unknown revision or path not in the working tree%', 0, false),
     ('Investigate: Non fast-forward', '%(non-fast-forward)%', 0, false) ;")
 
-# rubocop:enable LineLength
+# rubocop:enable Metrics/LineLength
 FailureGroup.categorize

--- a/script/populate_license_permissions
+++ b/script/populate_license_permissions
@@ -1,7 +1,7 @@
 #! /usr/bin/env ruby
 # frozen_string_literal: true
 
-# rubocop:disable LineLength
+# rubocop:disable Metrics/LineLength
 
 raise 'RAILS_ENV is undefined' unless ENV['RAILS_ENV']
 
@@ -188,4 +188,4 @@ end
 ['Include Copyright', 'Include License', 'Distribute Original', 'Disclose Source', 'Include Install Instructions', 'Compensate Damages'].each do |required|
   assign_permission(license, required, 'required')
 end
-# rubocop:enable LineLength
+# rubocop:enable Metrics/LineLength

--- a/script/rename_url_name_to_vanity_url_in_organization_edits
+++ b/script/rename_url_name_to_vanity_url_in_organization_edits
@@ -1,7 +1,11 @@
 #! /usr/bin/env ruby
 # frozen_string_literal: true
 
+# rubocop:disable SkipsModelValidations
+
 raise 'RAILS_ENV is undefined' unless ENV['RAILS_ENV']
 
 require_relative '../config/environment'
 puts PropertyEdit.where(target_type: 'Organization').for_property('url_name').update_all(key: 'vanity_url')
+
+# rubocop:enable SkipsModelValidations

--- a/script/rss_feed_update_next_fetch_to_past_date
+++ b/script/rss_feed_update_next_fetch_to_past_date
@@ -1,9 +1,13 @@
 #! /usr/bin/env ruby
 # frozen_string_literal: true
 
+# rubocop:disable SkipsModelValidations
+
 raise 'RAILS_ENV is undefined' unless ENV['RAILS_ENV']
 
 require_relative '../config/environment'
 RssFeed.where(id: RssSubscription.not_deleted.select('rss_feed_id'))
        .where("(next_fetch >= NOW() AT TIME ZONE 'UTC') AND error IS NOT NULL")
        .update_all(next_fetch: Time.current - 1.day)
+
+# rubocop:enable SkipsModelValidations

--- a/test/.rubocop.yml
+++ b/test/.rubocop.yml
@@ -1,5 +1,8 @@
 inherit_from: ../.rubocop.yml
 
+Rails/SkipsModelValidations:
+  Enabled: false
+
 Metrics/AbcSize:
   Enabled: false
 

--- a/test/.rubocop.yml
+++ b/test/.rubocop.yml
@@ -3,10 +3,7 @@ inherit_from: ../.rubocop.yml
 Metrics/AbcSize:
   Enabled: false
 
-ClassLength:
-  Enabled: false
-
-AbcSize:
+Metrics/ClassLength:
   Enabled: false
 
 Metrics/MethodLength:

--- a/test/.rubocop.yml
+++ b/test/.rubocop.yml
@@ -1,5 +1,8 @@
 inherit_from: ../.rubocop.yml
 
+Rails/DynamicFindBy:
+  Enabled: false
+
 Rails/SkipsModelValidations:
   Enabled: false
 

--- a/test/helpers/blog_link_helper_test.rb
+++ b/test/helpers/blog_link_helper_test.rb
@@ -8,7 +8,7 @@ class BlogLinkHelperTest < ActionView::TestCase
   describe 'blog_link_to' do
     it 'should return proper blog link' do
       BLOG_LINKS.each do |k, v|
-        link = "<a class='meta' href='http://blog.openhub.net/#{v}' target='_blank'>rest</a>".html_safe
+        link = safe_text("<a class='meta' href='http://blog.openhub.net/#{v}' target='_blank'>rest</a>")
         blog_link_to(link: k, link_text: 'rest').must_equal link
       end
     end

--- a/test/helpers/edits_helper_test.rb
+++ b/test/helpers/edits_helper_test.rb
@@ -46,7 +46,7 @@ class EditsHelperTest < ActionView::TestCase
         enlistment = create_enlistment_with_code_location
         @parent = enlistment.project
         edit = create(:create_edit, target: enlistment)
-        edit_show_subject(edit).must_match "Branch: #{enlistment.code_location.branch}"
+        edit_show_subject(edit, @parent).must_match "Branch: #{enlistment.code_location.branch}"
       end
 
       it 'should not display neither branch nor module name if both are empty' do
@@ -54,7 +54,7 @@ class EditsHelperTest < ActionView::TestCase
         enlistment.code_location = CodeLocation.new
         @parent = enlistment.project
         edit = create(:create_edit, target: enlistment)
-        edit_show_subject(edit).wont_match 'Branch: '
+        edit_show_subject(edit, @parent).wont_match 'Branch: '
       end
     end
   end

--- a/test/helpers/forums_helper_test.rb
+++ b/test/helpers/forums_helper_test.rb
@@ -42,19 +42,20 @@ class ForumsHelperTest < ActionView::TestCase
 
   it 'should return two sections' do
     @forum = forum
-    forums_sidebar.length.must_equal 2
+    forums_sidebar(@forum).length.must_equal 2
   end
 
   it 'should return three sections' do
-    forums_sidebar.length.must_equal 2
+    @forum = forum
+    forums_sidebar(@forum).length.must_equal 2
   end
 
   it 'should return forum menu list' do
     @forum = forum
-    forums_sidebar.must_equal forum_sidebar
+    forums_sidebar(@forum).must_equal forum_sidebar
   end
 
   it 'should return admin forum menu list' do
-    forums_sidebar.must_equal admin_sidebar
+    forums_sidebar(nil).must_equal admin_sidebar
   end
 end

--- a/test/helpers/page_context_helper_test.rb
+++ b/test/helpers/page_context_helper_test.rb
@@ -73,7 +73,7 @@ class PageContextHelperTest < ActionView::TestCase
   it 'should return forum page context' do
     Object.any_instance.stubs(:current_user_is_admin?).returns(true)
     @forum = rails
-    forum_context
+    forum_context(@forum)
     page_context.delete(:footer_menu_list)
     page_context.must_equal forum_menus
   end

--- a/test/helpers/projects_helper_test.rb
+++ b/test/helpers/projects_helper_test.rb
@@ -146,7 +146,7 @@ class ProjectsHelperTest < ActionView::TestCase
     it 'should return project managers list' do
       project_manager = create(:manage)
       @project = project_manager.target
-      project_managers_list.must_match project_manager.account.name
+      project_managers_list(@project).must_match project_manager.account.name
     end
   end
 

--- a/test/helpers/site_features_helper_test.rb
+++ b/test/helpers/site_features_helper_test.rb
@@ -11,14 +11,14 @@ class SiteFeaturesHelperTest < ActionView::TestCase
 
   describe 'features_hash' do
     it 'should return a hash' do
-      features_hash.wont_be_empty
-      features_hash.class.must_equal Hash
+      features_hash(@project).wont_be_empty
+      features_hash(@project).class.must_equal Hash
     end
   end
 
   describe 'random_site_features' do
     it 'should return a set of four random features' do
-      random_site_features.length.must_equal 4
+      random_site_features(@project).length.must_equal 4
     end
   end
 end

--- a/test/integration/edit_history_test.rb
+++ b/test/integration/edit_history_test.rb
@@ -12,7 +12,7 @@ class EditHistoryTest < ActionDispatch::IntegrationTest
         login_as create(:account)
         @parent = project
         project.update_attribute :description, Faker::Lorem.sentence(100)
-        xhr :get, show_edit_path(project.edits.where(key: 'description').last)
+        xhr :get, show_edit_path(project.edits.where(key: 'description').last, @parent)
         assert_response :success
         assert response.body.match(/\[More\]/)
         assert response.body.match(/\[Less\]/)

--- a/test/lib/widget_badge/account_test.rb
+++ b/test/lib/widget_badge/account_test.rb
@@ -3,7 +3,6 @@
 require 'test_helper'
 require 'test_helpers/image_helper'
 
-# rubocop: disable Lint/UnneededSplatExpansion
 describe 'WidgetBadge::Account' do
   describe '#create' do
     it 'must create the badge successfully' do
@@ -33,7 +32,8 @@ describe 'WidgetBadge::Account' do
     it 'must produce an image without text when no name' do
       options = { kudo_rank: 1, kudos: 2, commits: 39 }
 
-      result_image = WidgetBadge::Account.send :add_text, *[base_image, options]
+      array = [base_image, options]
+      result_image = WidgetBadge::Account.send :add_text, *array
       expected_image_path = Rails.root.join('test', 'data', 'widget_badge', 'account', 'text_without_name.png')
 
       compare_images(result_image.path, expected_image_path, 0.1)
@@ -42,7 +42,8 @@ describe 'WidgetBadge::Account' do
     it 'must produce an image without commits and kudos when not present' do
       options = { kudo_rank: 1, name: 'sara' }
 
-      result_image = WidgetBadge::Account.send :add_text, *[base_image, options]
+      array = [base_image, options]
+      result_image = WidgetBadge::Account.send :add_text, *array
       expected_image_path = Rails.root.join('test', 'data', 'widget_badge',
                                             'account', 'text_without_commits_and_kudos.png')
 
@@ -54,11 +55,11 @@ describe 'WidgetBadge::Account' do
     it 'must succesfully create a image with a given text' do
       options = WidgetBadge::Account::DEFAULT_FONT_OPTIONS
 
-      result_image = WidgetBadge::Account.send :new_text_image, *['Some Text', options]
+      array = ['Some Text', options]
+      result_image = WidgetBadge::Account.send :new_text_image, *array
       expected_image_path = Rails.root.join('test', 'data', 'widget_badge', 'account', 'new_text_image.png')
 
       compare_images(result_image.path, expected_image_path, 0.1)
     end
   end
 end
-# rubocop: enable Lint/UnneededSplatExpansion

--- a/test/lib/widget_badge/partner_test.rb
+++ b/test/lib/widget_badge/partner_test.rb
@@ -3,7 +3,6 @@
 require 'test_helper'
 require 'test_helpers/image_helper'
 
-# rubocop: disable Lint/UnneededSplatExpansion
 describe 'WidgetBadge::Partner' do
   describe '#create' do
     it 'must create the badge successfully' do
@@ -28,7 +27,8 @@ describe 'WidgetBadge::Partner' do
       text = '124k Lines'
       options = { opacity: 70 }
 
-      result_image = WidgetBadge::Partner.send :add_text, *[text, options]
+      array = [text, options]
+      result_image = WidgetBadge::Partner.send :add_text, *array
       expected_image_path = Rails.root.join('test', 'data', 'widget_badge', 'partner', 'add_text.png')
 
       compare_images(result_image.path, expected_image_path, 0.1)
@@ -38,7 +38,8 @@ describe 'WidgetBadge::Partner' do
       text = ''
       options = { opacity: 70 }
 
-      result_image = WidgetBadge::Partner.send :add_text, *[text, options]
+      array = [text, options]
+      result_image = WidgetBadge::Partner.send :add_text, *array
       expected_image_path = Rails.root.join('test', 'data', 'widget_badge', 'partner', 'text_without_name.png')
 
       compare_images(result_image.path, expected_image_path, 0.1)
@@ -49,11 +50,11 @@ describe 'WidgetBadge::Partner' do
     it 'must succesfully create a image with a given text' do
       options = WidgetBadge::Partner::DEFAULT_FONT_OPTIONS
 
-      result_image = WidgetBadge::Partner.send :new_text_image, *['Some Text', options]
+      array = ['Some Text', options]
+      result_image = WidgetBadge::Partner.send :new_text_image, *array
       expected_image_path = Rails.root.join('test', 'data', 'widget_badge', 'partner', 'new_text_image.png')
 
       compare_images(result_image.path, expected_image_path, 0.1)
     end
   end
 end
-# rubocop: enable Lint/UnneededSplatExpansion

--- a/test/lib/widget_badge/thin_test.rb
+++ b/test/lib/widget_badge/thin_test.rb
@@ -3,7 +3,6 @@
 require 'test_helper'
 require 'test_helpers/image_helper'
 
-# rubocop: disable Lint/UnneededSplatExpansion
 describe 'WidgetBadge::Thin' do
   describe '#create' do
     # We were unable to compare the gifs. So we instead just check for successful method call.
@@ -25,7 +24,8 @@ describe 'WidgetBadge::Thin' do
       text = '124k Lines'
       options = { y_offset: -1, blur: 70 }
 
-      result_image = WidgetBadge::Thin.send :add_text, *[text, options]
+      array = [text, options]
+      result_image = WidgetBadge::Thin.send :add_text, *array
       expected_image_path = Rails.root.join('test', 'data', 'widget_badge', 'thin', 'openhub_and_text.png')
 
       compare_images(result_image.path, expected_image_path, 0.1)
@@ -36,11 +36,11 @@ describe 'WidgetBadge::Thin' do
     it 'must create a image with a given text' do
       options = { y_offset: -1, blur: 70, align: :center }
 
-      result_image = WidgetBadge::Thin.send :new_text_image, *['Some Text', options]
+      array = ['Some Text', options]
+      result_image = WidgetBadge::Thin.send :new_text_image, *array
       expected_image_path = Rails.root.join('test', 'data', 'widget_badge', 'thin', 'new_text_image.png')
 
       compare_images(result_image.path, expected_image_path, 0.13)
     end
   end
 end
-# rubocop: enable Lint/UnneededSplatExpansion


### PR DESCRIPTION
This PR addresses replacing the existing `rubocop` gem with `rubocop-rails`, and correcting any issues found by the new gem.  
Rubocop has moved Rails cops to separate gem 'rubocop-rails'. So, we need to replace 'rubocop' gem with 'rubocop-rails'.