### PR TITLE
OTWO 5804 - sort vulnerabilities dropdown by version number

### DIFF
--- a/app/controllers/concerns/vulnerability_filters.rb
+++ b/app/controllers/concerns/vulnerability_filters.rb
@@ -42,6 +42,8 @@ module VulnerabilityFilters
                         @releases.sort_by_release_date
                       end
     @minor_versions = @minor_versions.select_within_years(filter_period_param) if filter_period_param.present?
+    @minor_versions = sort_by_version_number(@minor_versions)
+
     reset_release
   end
 
@@ -52,6 +54,10 @@ module VulnerabilityFilters
     order = { col: sort_col_param, direction: (params[:sort] || {}).fetch(:direction, 'ASC') }
     @vulnerabilities = Vulnerability.details(filter_version_param, filter: filter, sort: order)
                                     .paginate(page: page_param, per_page: 10)
+  end
+
+  def sort_by_version_number(versions)
+    versions.sort_by { |v| ( (_v = v.version.split('.').map(&:to_i))==[0] ) ? v.version.split('').map { |c| c.bytes.first.to_i*-1 } : _v }.reverse
   end
 
   def set_default_filter_period_param

--- a/app/controllers/concerns/vulnerability_filters.rb
+++ b/app/controllers/concerns/vulnerability_filters.rb
@@ -42,8 +42,6 @@ module VulnerabilityFilters
                         @releases.sort_by_release_date
                       end
     @minor_versions = @minor_versions.select_within_years(filter_period_param) if filter_period_param.present?
-    @minor_versions = sort_by_version_number(@minor_versions)
-
     reset_release
   end
 
@@ -54,10 +52,6 @@ module VulnerabilityFilters
     order = { col: sort_col_param, direction: (params[:sort] || {}).fetch(:direction, 'ASC') }
     @vulnerabilities = Vulnerability.details(filter_version_param, filter: filter, sort: order)
                                     .paginate(page: page_param, per_page: 10)
-  end
-
-  def sort_by_version_number(versions)
-    versions.sort_by { |v| ( (_v = v.version.split('.').map(&:to_i))==[0] ) ? v.version.split('').map { |c| c.bytes.first.to_i*-1 } : _v }.reverse
   end
 
   def set_default_filter_period_param

--- a/app/helpers/vulnerabilities_helper.rb
+++ b/app/helpers/vulnerabilities_helper.rb
@@ -60,7 +60,7 @@ module VulnerabilitiesHelper
     if vanity_url == 'android'
       releases.sort { |a,b| b.version <=> a.version }
     else
-      releases.sort_by { |r| ( (_r = r.version.split('.').map(&:to_i))==[0] ) ? r.version.split('').map { |c| c.bytes.first.to_i*-1 } : _r }.reverse
+      releases.sort_by { |release| release_version_to_array(release) }.reverse
     end
   end
 
@@ -126,5 +126,43 @@ module VulnerabilitiesHelper
       asc_desc_icon = current_direction == 'desc' ? ['hidden', ''] : ['', 'hidden']
     end
     asc_desc_icon
+  end
+
+  private
+
+  ###
+  # 1.0.0
+  # 1.0.0-rc.1
+  # 1.0.0-beta.11
+  # 1.0.0-beta.2
+  # 1.0.0-beta
+  # 1.0.0-alpha.beta
+  # 1.0.0-alpha.1 
+  # 1.0.0-alpha
+  
+  def release_version_to_array(release)
+    # (_array = release.version.split('.').map(&:to_i))==[0] ) ? release.version.split('').map { |char| char.bytes.first.to_i*-1 } : _array } 
+    _array = release.version.split('.').map do |token|
+      get_release_version_array(token)
+    end
+  end
+
+  def get_release_version_array(token)
+    # returns array of int or char values
+    val = token.to_i
+    val.to_s == token ? [val] : get_token_char_array(token)
+  end
+
+  def get_token_char_array(token)
+    token.chars.map do |char|
+      case char 
+      when '0'..'9'
+        char.to_s.to_i
+      when 'A'..'Z','a'..'z'
+        char.bytes.first.to_i*-1
+      when '-','+','_'
+        char.bytes.first.to_i*-1
+      end
+    end
   end
 end

--- a/app/helpers/vulnerabilities_helper.rb
+++ b/app/helpers/vulnerabilities_helper.rb
@@ -130,25 +130,13 @@ module VulnerabilitiesHelper
 
   private
 
-  ###
-  # 1.0.0
-  # 1.0.0-rc.1
-  # 1.0.0-beta.11
-  # 1.0.0-beta.2
-  # 1.0.0-beta
-  # 1.0.0-alpha.beta
-  # 1.0.0-alpha.1 
-  # 1.0.0-alpha
-  
   def release_version_to_array(release)
-    # (_array = release.version.split('.').map(&:to_i))==[0] ) ? release.version.split('').map { |char| char.bytes.first.to_i*-1 } : _array } 
     _array = release.version.split('.').map do |token|
       get_release_version_array(token)
     end
   end
 
   def get_release_version_array(token)
-    # returns array of int or char values
     val = token.to_i
     val.to_s == token ? [val] : get_token_char_array(token)
   end

--- a/app/helpers/vulnerabilities_helper.rb
+++ b/app/helpers/vulnerabilities_helper.rb
@@ -54,6 +54,16 @@ module VulnerabilitiesHelper
                        selected: filter_severity_param, disabled: disabled_severities)
   end
 
+  def sort_releases_by_version_number(releases)
+    return nil if releases.nil?
+    vanity_url = releases.first.project_security_set.project.vanity_url
+    if vanity_url == 'android'
+      releases.sort { |a,b| b.version <=> a.version }
+    else
+      releases.sort_by { |r| ( (_r = r.version.split('.').map(&:to_i))==[0] ) ? r.version.split('').map { |c| c.bytes.first.to_i*-1 } : _r }.reverse
+    end
+  end
+
   def severities
     Vulnerability.severities.keys
   end

--- a/app/helpers/vulnerabilities_helper.rb
+++ b/app/helpers/vulnerabilities_helper.rb
@@ -138,18 +138,32 @@ module VulnerabilitiesHelper
 
   def get_release_version_array(token)
     val = token.to_i
-    val.to_s == token ? [val] : get_token_char_array(token)
+    val.to_s == token ? [val, 0] : get_token_char_array(token)
   end
 
   def get_token_char_array(token)
-    token.chars.map do |char|
-      case char 
-      when '0'..'9'
-        char.to_s.to_i
-      when 'A'..'Z','a'..'z'
-        char.bytes.first.to_i*-1
-      when '-','+','_'
-        char.bytes.first.to_i*-1
+    if token.include?('-')
+      token1, token2 = token.split('-')
+      [token1.to_i, get_token_char_array(token2)].flatten
+    else
+      case token
+      when 'rc'
+        [-1]
+      when 'beta'
+        [-2]
+      when 'alpha'
+        [-3]
+      else
+        token.chars.map do |char|
+          case char 
+          when '0'..'9'
+            char.to_s.to_i
+          when 'A'..'Z','a'..'z'
+            char.bytes.first.to_i*-1
+          when '-','+','_'
+            char.bytes.first.to_i*-1
+          end
+        end
       end
     end
   end

--- a/app/helpers/vulnerabilities_helper.rb
+++ b/app/helpers/vulnerabilities_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop: disable Metrics/ModuleLength
+
 module VulnerabilitiesHelper
   EMPTY_SEVERITY = 'unknown_severity'
 
@@ -56,9 +58,10 @@ module VulnerabilitiesHelper
 
   def sort_releases_by_version_number(releases)
     return nil if releases.nil?
+
     vanity_url = releases.first.project_security_set.project.vanity_url
     if vanity_url == 'android'
-      releases.sort { |a,b| b.version <=> a.version }
+      releases.sort { |a, b| b.version <=> a.version }
     else
       releases.sort_by { |release| release_version_to_array(release) }.reverse
     end
@@ -138,33 +141,38 @@ module VulnerabilitiesHelper
 
   def get_release_version_array(token)
     val = token.to_i
-    val.to_s == token ? [val, 0] : get_token_char_array(token)
+    val.to_s == token ? [val, 0] : get_token_array(token)
   end
 
-  def get_token_char_array(token)
+  def get_token_array(token)
     if token.include?('-')
       token1, token2 = token.split('-')
-      [token1.to_i, get_token_char_array(token2)].flatten
+      [token1.to_i, get_token_array(token2)].flatten
     else
-      case token
-      when 'rc'
-        [-1]
-      when 'beta'
-        [-2]
-      when 'alpha'
-        [-3]
-      else
-        token.chars.map do |char|
-          case char 
-          when '0'..'9'
-            char.to_s.to_i
-          when 'A'..'Z','a'..'z'
-            char.bytes.first.to_i*-1
-          when '-','+','_'
-            char.bytes.first.to_i*-1
-          end
+      get_token_char_array(token)
+    end
+  end
+
+  # rubocop: disable Metrics/MethodLength
+  def get_token_char_array(token)
+    case token
+    when 'rc'
+      [-1]
+    when 'beta'
+      [-2]
+    when 'alpha'
+      [-3]
+    else
+      token.chars.map do |char|
+        case char
+        when '0'..'9'
+          char.to_s.to_i
+        when 'A'..'Z', 'a'..'z', '-', '+', '_'
+          char.bytes.first.to_i * -1
         end
       end
     end
   end
+  # rubocop: enable Metrics/MethodLength
 end
+# rubocop: enable Metrics/ModuleLength

--- a/app/views/vulnerabilities/_version_filter.html.haml
+++ b/app/views/vulnerabilities/_version_filter.html.haml
@@ -1,7 +1,7 @@
 .vulnerability_filter_wrapper.vulnerability_filter_version
   %span.title= t('.version')
   = select_tag 'vulnerability[filter][version]',
-    options_from_collection_for_select(@minor_versions.presence || no_versions_available,
+    options_from_collection_for_select(sort_releases_by_version_number(@minor_versions).presence || no_versions_available,
       'id', 'version', filter_version_param),
       class: 'ctrl vulnerability_filter'
 .vulnerability_filter_wrapper.vulnerability_filter_severity

--- a/test/helpers/vulnerabilities_helper_test.rb
+++ b/test/helpers/vulnerabilities_helper_test.rb
@@ -60,14 +60,14 @@ class VulnerabilitiesHelperTest < ActionView::TestCase
     it 'should correctly filter mixed style of version releases' do
       project = FactoryBot.create(:project)
       pss = FactoryBot.create(:project_security_set, project: project)
-      rel1 = FactoryBot.create(:release, version: '1.0.0-alpha.1')
-      rel2 = FactoryBot.create(:release, version: '1.0.0-alpha')
-      rel3 = FactoryBot.create(:release, version: '1.0.0-beta.11')
+      rel1 = FactoryBot.create(:release, version: '1.0.0-alpha')
+      rel2 = FactoryBot.create(:release, version: '1.0.0-alpha.1')
+      rel3 = FactoryBot.create(:release, version: '1.0.0-beta')
       rel4 = FactoryBot.create(:release, version: '1.0.0-beta.2')
-      rel5 = FactoryBot.create(:release, version: '1.0.0-beta')
+      rel5 = FactoryBot.create(:release, version: '1.0.0-beta.11')
       rel6 = FactoryBot.create(:release, version: '1.0.0-rc.1')
       rel7 = FactoryBot.create(:release, version: '1.0.0')
-      sort_releases_by_version_number(Release.all).must_equal [rel1, rel2, rel3, rel4, rel5, rel6, rel7]
+      sort_releases_by_version_number(Release.all).must_equal [rel7, rel6, rel5, rel4, rel3, rel2, rel1]
     end
 
   end

--- a/test/helpers/vulnerabilities_helper_test.rb
+++ b/test/helpers/vulnerabilities_helper_test.rb
@@ -27,4 +27,24 @@ class VulnerabilitiesHelperTest < ActionView::TestCase
       major_releases(Release.all, android).must_equal ['android-5.0.0_r1', 'android-2.0.5_r1', 'android-3.1.0_r1']
     end
   end
+
+  describe '' do
+    it 'should correctly filter version releases' do
+      project = FactoryBot.create(:project)
+      pss = FactoryBot.create(:project_security_set, project: project)
+      rel1 = FactoryBot.create(:release, version: '10.1')
+      rel2 = FactoryBot.create(:release, version: '21.1')
+      rel3 = FactoryBot.create(:release, version: '32.1')
+      sort_releases_by_version_number(Release.all).must_equal [rel3, rel2, rel1]
+    end
+
+    it 'should correctly filter android version releases' do
+      android = FactoryBot.create(:project, vanity_url: 'android')
+      pss = FactoryBot.create(:project_security_set, project: android)
+      rel1 = FactoryBot.create(:major_release_one, version: 'android-5.0.0_r1', project_security_set: pss)
+      rel2 = FactoryBot.create(:major_release_two, version: 'android-2.0.5_r1', project_security_set: pss)
+      rel3 = FactoryBot.create(:major_release_three, version: 'android-3.1.0_r1', project_security_set: pss)
+      sort_releases_by_version_number(Release.all).must_equal [rel1, rel3, rel2]
+    end
+  end
 end

--- a/test/helpers/vulnerabilities_helper_test.rb
+++ b/test/helpers/vulnerabilities_helper_test.rb
@@ -31,7 +31,7 @@ class VulnerabilitiesHelperTest < ActionView::TestCase
   describe '' do
     it 'should correctly filter version releases' do
       project = FactoryBot.create(:project)
-      pss = FactoryBot.create(:project_security_set, project: project)
+      FactoryBot.create(:project_security_set, project: project)
       rel1 = FactoryBot.create(:release, version: '10.1.1')
       rel2 = FactoryBot.create(:release, version: '10.1.2')
       rel3 = FactoryBot.create(:release, version: '10.1.3')
@@ -41,7 +41,7 @@ class VulnerabilitiesHelperTest < ActionView::TestCase
 
     it 'should correctly filter version releases w/ alphabetic chars' do
       project = FactoryBot.create(:project)
-      pss = FactoryBot.create(:project_security_set, project: project)
+      FactoryBot.create(:project_security_set, project: project)
       rel1 = FactoryBot.create(:release, version: 'PRE_RELEASE')
       rel2 = FactoryBot.create(:release, version: 'ALPHA_RELEASE')
       rel3 = FactoryBot.create(:release, version: 'BETA_RELEASE')
@@ -59,7 +59,7 @@ class VulnerabilitiesHelperTest < ActionView::TestCase
 
     it 'should correctly filter mixed style of version releases' do
       project = FactoryBot.create(:project)
-      pss = FactoryBot.create(:project_security_set, project: project)
+      FactoryBot.create(:project_security_set, project: project)
       rel1 = FactoryBot.create(:release, version: '1.0.0-alpha')
       rel2 = FactoryBot.create(:release, version: '1.0.0-alpha.1')
       rel3 = FactoryBot.create(:release, version: '1.0.0-beta')
@@ -69,6 +69,5 @@ class VulnerabilitiesHelperTest < ActionView::TestCase
       rel7 = FactoryBot.create(:release, version: '1.0.0')
       sort_releases_by_version_number(Release.all).must_equal [rel7, rel6, rel5, rel4, rel3, rel2, rel1]
     end
-
   end
 end

--- a/test/helpers/vulnerabilities_helper_test.rb
+++ b/test/helpers/vulnerabilities_helper_test.rb
@@ -32,10 +32,11 @@ class VulnerabilitiesHelperTest < ActionView::TestCase
     it 'should correctly filter version releases' do
       project = FactoryBot.create(:project)
       pss = FactoryBot.create(:project_security_set, project: project)
-      rel1 = FactoryBot.create(:release, version: '10.1')
-      rel2 = FactoryBot.create(:release, version: '21.1')
-      rel3 = FactoryBot.create(:release, version: '32.1')
-      sort_releases_by_version_number(Release.all).must_equal [rel3, rel2, rel1]
+      rel1 = FactoryBot.create(:release, version: '10.1.1')
+      rel2 = FactoryBot.create(:release, version: '10.1.2')
+      rel3 = FactoryBot.create(:release, version: '10.1.3')
+      rel4 = FactoryBot.create(:release, version: '10.1')
+      sort_releases_by_version_number(Release.all).must_equal [rel3, rel2, rel1, rel4]
     end
 
     it 'should correctly filter version releases w/ alphabetic chars' do
@@ -55,5 +56,19 @@ class VulnerabilitiesHelperTest < ActionView::TestCase
       rel3 = FactoryBot.create(:major_release_three, version: 'android-3.1.0_r1', project_security_set: pss)
       sort_releases_by_version_number(Release.all).must_equal [rel1, rel3, rel2]
     end
+
+    it 'should correctly filter mixed style of version releases' do
+      project = FactoryBot.create(:project)
+      pss = FactoryBot.create(:project_security_set, project: project)
+      rel1 = FactoryBot.create(:release, version: '1.0.0-alpha.1')
+      rel2 = FactoryBot.create(:release, version: '1.0.0-alpha')
+      rel3 = FactoryBot.create(:release, version: '1.0.0-beta.11')
+      rel4 = FactoryBot.create(:release, version: '1.0.0-beta.2')
+      rel5 = FactoryBot.create(:release, version: '1.0.0-beta')
+      rel6 = FactoryBot.create(:release, version: '1.0.0-rc.1')
+      rel7 = FactoryBot.create(:release, version: '1.0.0')
+      sort_releases_by_version_number(Release.all).must_equal [rel1, rel2, rel3, rel4, rel5, rel6, rel7]
+    end
+
   end
 end

--- a/test/helpers/vulnerabilities_helper_test.rb
+++ b/test/helpers/vulnerabilities_helper_test.rb
@@ -38,6 +38,15 @@ class VulnerabilitiesHelperTest < ActionView::TestCase
       sort_releases_by_version_number(Release.all).must_equal [rel3, rel2, rel1]
     end
 
+    it 'should correctly filter version releases w/ alphabetic chars' do
+      project = FactoryBot.create(:project)
+      pss = FactoryBot.create(:project_security_set, project: project)
+      rel1 = FactoryBot.create(:release, version: 'PRE_RELEASE')
+      rel2 = FactoryBot.create(:release, version: 'ALPHA_RELEASE')
+      rel3 = FactoryBot.create(:release, version: 'BETA_RELEASE')
+      sort_releases_by_version_number(Release.all).must_equal [rel2, rel3, rel1]
+    end
+
     it 'should correctly filter android version releases' do
       android = FactoryBot.create(:project, vanity_url: 'android')
       pss = FactoryBot.create(:project_security_set, project: android)


### PR DESCRIPTION
This PR addresses an issue where the dropdown listing for Vulnerabilities on the `projects#security` page is sorted by respective release date and should be correctly sorted using semantic versioning.  Using a sort by semantic versioning will correctly group all releases listed and not jumble the listing based on the most recent releases; the `projects#security` UI still presents a vulnerability timeline which lists the respective releases for the selected time span.

Refer to https://semver.org for a description on semantic versioning.

This PR converts each respective version string to an array of int for each element in the version string; non-numeric chars, '+', '-', and '_' are translated to their equivalent ASCII values and multiplied by -1 with respect to sorting.  The sorting is done in ascending order, which is then reversed before rendering the dropdown list.  `alpha`, `beta`, and `rc` are reserved terms that have a special sorting order; an `alpha` release precedes a `beta` release which precedes a release candidate (`rc`); the sorting takes this into account and assigns a negative value which sorts these releases with precedence over other 'named' releases, or those which include build information `(.'+...')`.  A few edge cases likely exist with those releases which include build information in that they will be listed immediately _before_ a minor version instead of immediately _after_.