### PR TITLE
OTWO-5831: Fix invalid version patterns breaking project#security

### DIFF
--- a/app/helpers/vulnerabilities_helper.rb
+++ b/app/helpers/vulnerabilities_helper.rb
@@ -145,6 +145,8 @@ module VulnerabilitiesHelper
   end
 
   def get_token_array(token)
+    return [] if token.nil?
+
     if token.include?('-')
       token1, token2 = token.split('-')
       [token1.to_i, get_token_array(token2)].flatten
@@ -167,7 +169,7 @@ module VulnerabilitiesHelper
         case char
         when '0'..'9'
           char.to_s.to_i
-        when 'A'..'Z', 'a'..'z', '-', '+', '_'
+        else
           char.bytes.first.to_i * -1
         end
       end

--- a/test/helpers/vulnerabilities_helper_test.rb
+++ b/test/helpers/vulnerabilities_helper_test.rb
@@ -69,5 +69,35 @@ class VulnerabilitiesHelperTest < ActionView::TestCase
       rel7 = FactoryBot.create(:release, version: '1.0.0')
       sort_releases_by_version_number(Release.all).must_equal [rel7, rel6, rel5, rel4, rel3, rel2, rel1]
     end
+
+    it 'should correctly filter invalid names of version releases' do
+      project = FactoryBot.create(:project)
+      FactoryBot.create(:project_security_set, project: project)
+      rel1 = FactoryBot.create(:release, version: 'Compose.NET 0.4b')
+      rel2 = FactoryBot.create(:release, version: 'Compose.NET 0.3b')
+      rel3 = FactoryBot.create(:release, version: 'Compose-.NET 0.8 for .NET 1.1')
+      rel4 = FactoryBot.create(:release, version: 'Compose-.NET 0.8.1 for .NET 1.1')
+      rel5 = FactoryBot.create(:release, version: 'Compose*.NET 0.7b')
+      sort_releases_by_version_number(Release.all).must_equal [rel4, rel3, rel5, rel1, rel2]
+    end
+
+    # rubocop: disable Metrics/LineLength
+    it 'should correctly filter a mix of valid and invalid version release names' do
+      project = FactoryBot.create(:project)
+      FactoryBot.create(:project_security_set, project: project)
+      rel1 = FactoryBot.create(:release, version: 'N/A')
+      rel2 = FactoryBot.create(:release, version: 'BEEing_5.0.3')
+      rel3 = FactoryBot.create(:release, version: 'BEEingXLib_7.0.0')
+      rel4 = FactoryBot.create(:release, version: 'BEEingLib_5.0.0')
+      rel5 = FactoryBot.create(:release, version: 'Sources')
+      rel6 = FactoryBot.create(:release, version: '3.0.0.5')
+      rel7 = FactoryBot.create(:release, version: '2.1.3')
+      rel8 = FactoryBot.create(:release, version: '3.0.0')
+      rel9 = FactoryBot.create(:release, version: 'Navicat BEEing Databases')
+      rel10 = FactoryBot.create(:release, version: 'BEEingDependencies')
+      rel11 = FactoryBot.create(:release, version: 'BEEingLibs')
+      sort_releases_by_version_number(Release.all).must_equal [rel6, rel8, rel7, rel10, rel4, rel11, rel3, rel2, rel1, rel9, rel5]
+    end
+    # rubocop: enable Metrics/LineLength
   end
 end


### PR DESCRIPTION
This PR fixes errors that block a user from accessing projects#security.

The error occurs when sorting the version names that comprise the dropdown in the Vulnerabilities section of the Projects Security page, and is related to non-standard semantic version patterns used within a number of projects hosted on OpenHub. 

The first fix recognizes non-standard chars in version names, such that `nil` is no longer assigned for non-standard chars in the array to be sorted, which was causing `comparison of Array with Array failed`

The second fix checks for a `nil` token passed to `get_token_array` and simply returns an empty array (`[]`).  Release names that ended with a hyphen (ie: `TestRelease-.x.y.z`) were found to cause this issue.

Tests have been augmented such that release names which were causing previous errors, now pass with every build.  