### PR TITLE
Disallow requests from bot

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -40,4 +40,7 @@ Disallow: /
 User-agent: MJ12bot
 Disallow: /
 
+User-agent: AhrefsBot
+Disallow: /
+
 Sitemap: http://www.openhub.net/sitemap_index.xml


### PR DESCRIPTION
Requests from this bot cause errors stating broken html.
This is cluttering our errbit logs.