### PR TITLE
OTWO-5760: Update the Explore People page using the Mockup

### DIFF
--- a/app/assets/stylesheets/account.sass
+++ b/app/assets/stylesheets/account.sass
@@ -1,5 +1,3 @@
-@import oh-colors
-
 #accounts_index_page, #people_index_page
   .account_details
     width: 220px

--- a/app/assets/stylesheets/accounts/show.sass
+++ b/app/assets/stylesheets/accounts/show.sass
@@ -1,5 +1,3 @@
-@import oh-colors
-
 #accounts_show_page
   color: black
   margin-top: -5px

--- a/app/assets/stylesheets/bootstrap.sass
+++ b/app/assets/stylesheets/bootstrap.sass
@@ -1,5 +1,3 @@
-@import oh-styles
-
 @font-face
   font-family: 'Glyphicons Halflings'
   src: font-url('glyphicons-halflings-regular.woff') format('woff')

--- a/app/assets/stylesheets/buttons.sass
+++ b/app/assets/stylesheets/buttons.sass
@@ -1,5 +1,3 @@
-@import "oh-styles"
-
 /** buttons **/
 
 .btn

--- a/app/assets/stylesheets/charts.sass
+++ b/app/assets/stylesheets/charts.sass
@@ -1,14 +1,5 @@
 @import 'https://code.highcharts.com/css/highcharts.css'
 
-$color0: color-gradient($PRIMARY_DARK_GRAY, 60)
-$color1: color-gradient($BLACK_DUCK_BLUE, 40)
-$color2: color-gradient($BLACK_DUCK_BLUE, 80)
-$color3: color-gradient($BLACK_DUCK_BLUE, 120)
-$color4: color-gradient($PRIMARY_PURPLE, 80)
-$color5: color-gradient($PRIMARY_PURPLE, 120)
-$color6: color-gradient($SECONDARY_ORANGE, 100)
-$colors: $color0 $color1 $color2 $color3 $color4 $color5 $color6 !default
-
 .watermark340 .highcharts-container
   background: asset-url("charts/watermark_340.png") no-repeat center
   background-size: contain
@@ -33,73 +24,127 @@ $colors: $color0 $color1 $color2 $color3 $color4 $color5 $color6 !default
   background: asset-url("charts/watermark_914.png") no-repeat center
   background-size: contain
 
-.highcharts-graph
-  stroke-width: 0px
+#vulnerabilities_index_page,
+#vulnerability_version_chart
+  .highcharts-series-inactive
+    opacity: 1.0
 
-.highcharts-point.highcharts-color-0,
-.highcharts-legend-item.highcharts-color-0 .highcharts-point,
-.highcharts-tooltip .highcharts-color-0
-.highcharts-color-0, .highcharts-pointhighcharts-color-0
-  fill: color-gradient($PRIMARY_DARK_GRAY, 60)
+  .highcharts-point.highcharts-color-0,
+  .highcharts-legend-item.highcharts-color-0 .highcharts-point,
+  .highcharts-tooltip .highcharts-color-0
+  .highcharts-color-0, .highcharts-pointhighcharts-color-0
+    @include vulnerabilities-high-severity-fill
 
-.highcharts-tooltip.highcharts-color-0,
-.highcharts-data-label-connector.highcharts-color-0
-  stroke: color-gradient($PRIMARY_DARK_GRAY, 60)
+  .highcharts-tooltip.highcharts-color-0,
+  .highcharts-data-label-connector.highcharts-color-0
+    @include vulnerabilities-high-severity-stroke
 
-.highcharts-point.highcharts-color-1,
-.highcharts-legend-item.highcharts-color-1 .highcharts-point,
-.highcharts-tooltip .highcharts-color-1
-  fill: color-gradient($BLACK_DUCK_BLUE, 40)
+  .highcharts-point.highcharts-color-1,
+  .highcharts-legend-item.highcharts-color-1 .highcharts-point,
+  .highcharts-tooltip .highcharts-color-1
+    @include vulnerabilities-medium-severity-fill
 
-.highcharts-tooltip.highcharts-color-1,
-.highcharts-data-label-connector.highcharts-color-1
-  stroke: color-gradient($BLACK_DUCK_BLUE, 40)
+  .highcharts-tooltip.highcharts-color-1,
+  .highcharts-data-label-connector.highcharts-color-1
+    @include vulnerabilities-medium-severity-stroke
 
-.highcharts-point.highcharts-color-2,
-.highcharts-legend-item.highcharts-color-2 .highcharts-point,
-.highcharts-tooltip .highcharts-color-2
-  fill: color-gradient($BLACK_DUCK_BLUE, 80)
+  .highcharts-point.highcharts-color-2,
+  .highcharts-legend-item.highcharts-color-2 .highcharts-point,
+  .highcharts-tooltip .highcharts-color-2
+    @include vulnerabilities-low-severity-fill
 
-.highcharts-tooltip.highcharts-color-2,
-.highcharts-data-label-connector.highcharts-color-2
-  stroke: color-gradient($BLACK_DUCK_BLUE, 80)
+  .highcharts-tooltip.highcharts-color-2,
+  .highcharts-data-label-connector.highcharts-color-2
+    @include vulnerabilities-low-severity-stroke
 
-.highcharts-point.highcharts-color-3,
-.highcharts-legend-item.highcharts-color-3 .highcharts-point,
-.highcharts-tooltip .highcharts-color-3
-  fill: color-gradient($BLACK_DUCK_BLUE, 120)
+  .highcharts-point.highcharts-color-3,
+  .highcharts-legend-item.highcharts-color-3 .highcharts-point,
+  .highcharts-tooltip .highcharts-color-3
+    @include vulnerabilities-unknown-severity-fill
 
-.highcharts-tooltip.highcharts-color-3,
-.highcharts-data-label-connector.highcharts-color-3
-  stroke: color-gradient($BLACK_DUCK_BLUE, 120)
+  .highcharts-tooltip.highcharts-color-3,
+  .highcharts-data-label-connector.highcharts-color-3
+    @include vulnerabilities-unknown-severity-stroke
 
-.highcharts-point.highcharts-color-4,
-.highcharts-legend-item.highcharts-color-4 .highcharts-point,
-.highcharts-tooltip .highcharts-color-4
-  fill: color-gradient($PRIMARY_PURPLE, 80)
+  .highcharts-column-series .highcharts-point-hover.highcharts-color-0,
+    @include vulnerabilities-high-severity-hover
 
-.highcharts-tooltip.highcharts-color-4,
-.highcharts-data-label-connector.highcharts-color-4
-  stroke: color-gradient($PRIMARY_PURPLE, 80)
+  .highcharts-column-series .highcharts-point-hover.highcharts-color-1,
+    @include vulnerabilities-medium-severity-hover
 
-.highcharts-point.highcharts-color-5,
-.highcharts-legend-item.highcharts-color-5 .highcharts-point,
-.highcharts-tooltip .highcharts-color-5
-  fill: color-gradient($PRIMARY_PURPLE, 120)
+  .highcharts-column-series .highcharts-point-hover.highcharts-color-2,
+    @include vulnerabilities-low-severity-hover
 
-.highcharts-tooltip.highcharts-color-5,
-.highcharts-data-label-connector.highcharts-color-5
-  stroke: color-gradient($PRIMARY_PURPLE, 120)
+  .highcharts-column-series .highcharts-point-hover.highcharts-color-3,
+    @include vulnerabilities-unknown-severity-hover
 
-.highcharts-point.highcharts-color-6,
-.highcharts-legend-item.highcharts-color-6 .highcharts-point,
-.highcharts-tooltip .highcharts-color-6
-  fill: color-gradient($SECONDARY_ORANGE, 100)
+#demographics_chart
+  .highcharts-graph
+    stroke-width: 0px
 
-.highcharts-tooltip.highcharts-color-6,
-.highcharts-data-label-connector.highcharts-color-6
-  stroke: color-gradient($SECONDARY_ORANGE, 100)
+  .highcharts-point-inactive
+    opacity: 1.0
 
-.highcharts-point-inactive
-  opacity: 1.0
+  .highcharts-point.highcharts-color-0,
+  .highcharts-legend-item.highcharts-color-0 .highcharts-point,
+  .highcharts-tooltip .highcharts-color-0
+  .highcharts-color-0, .highcharts-pointhighcharts-color-0
+    @include projects-demographics-inactive-fill
 
+  .highcharts-tooltip.highcharts-color-0,
+  .highcharts-data-label-connector.highcharts-color-0
+    @include projects-demographics-inactive-stroke
+
+  .highcharts-point.highcharts-color-1,
+  .highcharts-legend-item.highcharts-color-1 .highcharts-point,
+  .highcharts-tooltip .highcharts-color-1
+    @include projects-demographics-very-low-fill
+
+  .highcharts-tooltip.highcharts-color-1,
+  .highcharts-data-label-connector.highcharts-color-1
+    @include projects-demographics-very-low-stroke
+
+  .highcharts-point.highcharts-color-2,
+  .highcharts-legend-item.highcharts-color-2 .highcharts-point,
+  .highcharts-tooltip .highcharts-color-2
+    @include projects-demographics-low-fill
+
+  .highcharts-tooltip.highcharts-color-2,
+  .highcharts-data-label-connector.highcharts-color-2
+    @include projects-demographics-low-stroke
+
+  .highcharts-point.highcharts-color-3,
+  .highcharts-legend-item.highcharts-color-3 .highcharts-point,
+  .highcharts-tooltip .highcharts-color-3
+    @include projects-demographics-moderate-fill
+
+  .highcharts-tooltip.highcharts-color-3,
+  .highcharts-data-label-connector.highcharts-color-3
+    @include projects-demographics-moderate-stroke
+
+  .highcharts-point.highcharts-color-4,
+  .highcharts-legend-item.highcharts-color-4 .highcharts-point,
+  .highcharts-tooltip .highcharts-color-4
+    @include projects-demographics-high-fill
+
+  .highcharts-tooltip.highcharts-color-4,
+  .highcharts-data-label-connector.highcharts-color-4
+    @include projects-demographics-high-stroke
+
+  .highcharts-point.highcharts-color-5,
+  .highcharts-legend-item.highcharts-color-5 .highcharts-point,
+  .highcharts-tooltip .highcharts-color-5
+    @include projects-demographics-very-high-fill
+
+  .highcharts-tooltip.highcharts-color-5,
+  .highcharts-data-label-connector.highcharts-color-5
+    @include projects-demographics-very-high-stroke
+
+  .highcharts-point.highcharts-color-6,
+  .highcharts-legend-item.highcharts-color-6 .highcharts-point,
+  .highcharts-tooltip .highcharts-color-6
+    @include projects-demographics-new-fill
+
+  .highcharts-tooltip.highcharts-color-6,
+  .highcharts-data-label-connector.highcharts-color-6
+    @include projects-demographics-new-stroke

--- a/app/assets/stylesheets/chosen-overrides.sass
+++ b/app/assets/stylesheets/chosen-overrides.sass
@@ -1,35 +1,38 @@
 #value_select
   .chzn-container .chzn-drop, .chzn-container-single .chzn-single
-    border: 1px solid color-gradient($SECONDARY_SLATE_BLUE, 120)
+    border: 1px solid color-gradient($SECONDARY_LIGHT_PURPLE, 120)
   .chzn-container-active.chzn-with-drop .chzn-single
-    border: 1px solid color-gradient($SECONDARY_SLATE_BLUE, 120)
+    border: 1px solid color-gradient($SECONDARY_LIGHT_PURPLE, 120)
     box-shadow: none
   .chzn-container-single .chzn-single
     background-color: white
     background-image: none
     background: white none top left no-repeat
     filter: none
-    border: 1px solid #797979
+    border: 1px solid color-gradient($PRIMARY_DARK_GRAY, 120)
     height: 30px
   .chzn-container-active > .chzn-single
-    border: 1px solid color-gradient($SECONDARY_SLATE_BLUE, 120)
+    border: 1px solid color-gradient($SECONDARY_LIGHT_PURPLE, 120)
   .chzn-container
     .chzn-drop
       border-top: none
-      border-left: 1px solid color-gradient($SECONDARY_SLATE_BLUE, 120)
-      border-bottom: 1px solid color-gradient($SECONDARY_SLATE_BLUE, 120)
-      border-right: 1px solid color-gradient($SECONDARY_SLATE_BLUE, 120)
+      border-left: 1px solid color-gradient($SECONDARY_LIGHT_PURPLE, 120)
+      border-bottom: 1px solid color-gradient($SECONDARY_LIGHT_PURPLE, 120)
+      border-right: 1px solid color-gradient($SECONDARY_LIGHT_PURPLE, 120)
     .chzn-results .highlighted
-      background: color-gradient($SECONDARY_SLATE_BLUE, 120)
+      background: color-gradient($SECONDARY_LIGHT_PURPLE, 120)
       color: white
   .chzn-container-single .chzn-single
     border-radius: 0px
+
+.chzn-search
+  background-color: color-gradient($SECONDARY_LIGHT_PURPLE, 120)
 
 /* Some IE 7-9 fun with this next one - filter likes to override background
 
 #sort_by, #add_new_badge_form
   .chzn-container-single .chzn-search:after
-    color: color-gradient($SECONDARY_SLATE_BLUE, 120)
+    color: color-gradient($SECONDARY_LIGHT_PURPLE, 120)
   .chzn-container .chzn-results li
     color: white
 
@@ -40,50 +43,50 @@ div.chosen label
 
 #sort_by, #add_new_badge_form
   .chzn-container .chzn-drop, .chzn-container-single .chzn-single
-    background-color: #797979
+    background-color: color-gradient($PRIMARY_DARK_GRAY, 120)
     background-image: none
-    border: 1px solid color-gradient($SECONDARY_SLATE_BLUE, 120)
+    border: 1px solid color-gradient($SECONDARY_LIGHT_PURPLE, 120)
     color: white
     box-shadow: none !important
     border-radius: 0px
   .chzn-container-active.chzn-with-drop .chzn-single
-    border: 1px solid color-gradient($SECONDARY_SLATE_BLUE, 120)
+    border: 1px solid color-gradient($SECONDARY_LIGHT_PURPLE, 120)
     box-shadow: none
   .chzn-container-single .chzn-single div
-    background-color: #797979
-    background: #797979
+    background-color: color-gradient($PRIMARY_DARK_GRAY, 120)
+    background: color-gradient($PRIMARY_DARK_GRAY, 120)
     color: white
     /*border: 1px solid black;
   .chzn-single div b:before
     color: white
   .chzn-container-single .chzn-single
-    background-color: #797979
+    background-color: color-gradient($PRIMARY_DARK_GRAY, 120)
     background-image: none
-    background: #797979 none top left no-repeat
+    background: color-gradient($PRIMARY_DARK_GRAY, 120) none top left no-repeat
     filter: none
-    border: 1px solid #797979
+    border: 1px solid color-gradient($PRIMARY_DARK_GRAY, 120)
     height: 30px
   .chzn-container-active > .chzn-single
-    border: 1px solid color-gradient($SECONDARY_SLATE_BLUE, 120)
+    border: 1px solid color-gradient($SECONDARY_LIGHT_PURPLE, 120)
   .chzn-container .chzn-drop
     border-top: none
-    border-left: 1px solid color-gradient($SECONDARY_SLATE_BLUE, 120)
-    border-bottom: 1px solid color-gradient($SECONDARY_SLATE_BLUE, 120)
-    border-right: 1px solid color-gradient($SECONDARY_SLATE_BLUE, 120)
+    border-left: 1px solid color-gradient($SECONDARY_LIGHT_PURPLE, 120)
+    border-bottom: 1px solid color-gradient($SECONDARY_LIGHT_PURPLE, 120)
+    border-right: 1px solid color-gradient($SECONDARY_LIGHT_PURPLE, 120)
   .chzn-container-active .chzn-single-with-drop
     box-shadow: none
   .chzn-container .chzn-results
     .highlighted
-      background: color-gradient($SECONDARY_SLATE_BLUE, 120)
+      background: color-gradient($SECONDARY_LIGHT_PURPLE, 120)
       color: white
     .no-results
-      background: #797979
+      background: color-gradient($PRIMARY_DARK_GRAY, 120)
     li em
       background: none
   .chzn-container-multi .chzn-choices
-    background: #797979
+    background: color-gradient($PRIMARY_DARK_GRAY, 120)
   .chzn-container-active .chzn-choices
-    border: 1px solid color-gradient($SECONDARY_SLATE_BLUE, 120)
+    border: 1px solid color-gradient($SECONDARY_LIGHT_PURPLE, 120)
 
 /* Some IE 7-9 fun with this next one - filter likes to override background
 
@@ -98,7 +101,7 @@ div.chosen label
   box-shadow: none !important
 
 .chzn-container-active .chzn-choices
-  border: 1px solid color-gradient($SECONDARY_SLATE_BLUE, 120)
+  border: 1px solid color-gradient($SECONDARY_LIGHT_PURPLE, 120)
 
 /* OTWO-3025 Fix for IE9 -- Chosen jQuery Dropdown to have the orange color as background
 

--- a/app/assets/stylesheets/committers.sass
+++ b/app/assets/stylesheets/committers.sass
@@ -16,15 +16,14 @@
   margin-right: -10px !important
 
 .tick_selected
+  @include explore-people-tick-selected-colors
   font-size: 24px
-  color: #2BB72B
-  background-color: #fff
   border-radius: 50%
   cursor: pointer
 
 .tick_unselected
+  @include explore-people-tick-unselected-colors
   font-size: 24px
-  color: #898989
   position: relative
   z-index: 9999
   cursor: pointer

--- a/app/assets/stylesheets/dynamic.sass
+++ b/app/assets/stylesheets/dynamic.sass
@@ -1,5 +1,3 @@
-@import oh-styles
-
 // margin classes like margin_top_10, margin_left_5, margin_bottom_10..
 @each $pos in ('top', 'right', 'bottom', 'left')
   @each $pixel in (0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50)

--- a/app/assets/stylesheets/explore.sass
+++ b/app/assets/stylesheets/explore.sass
@@ -10,20 +10,21 @@
         line-height: 17px
     .icon-search
       &.search
+        @include explore-sidebar-icon-search-color
         cursor: pointer
         font-size: 18px
         position: relative
         top: 3px
     input
-      color: #202020
+      @include explore-sidebar-search-text-color
       &:-moz-placeholder
-        color: #202020
+        color: color-gradient($LIGHT_GRAY, 120)
         font-style: italic
       &:-ms-input-placeholder
-        color: #202020
+        color: color-gradient($LIGHT_GRAY, 120)
         font-style: italic
       &::-webkit-input-placeholder
-        color: #202020
+        color: color-gradient($LIGHT_GRAY, 120)
         font-style: italic
   .explore_search
     width: 173px

--- a/app/assets/stylesheets/footer.sass
+++ b/app/assets/stylesheets/footer.sass
@@ -1,12 +1,10 @@
-@import oh-styles
-
 footer
   @include footer-colors
 
   margin: 20px 0 0 0
   min-height: 250px
   padding-top: 10px
-  width: 980px
+  width: 960px
 
   .footer-left
     float: left

--- a/app/assets/stylesheets/forums_topics_posts.sass
+++ b/app/assets/stylesheets/forums_topics_posts.sass
@@ -1,5 +1,3 @@
-@import oh-colors
-
 .border_bottom_color
   border-bottom: 1px solid black
 

--- a/app/assets/stylesheets/home.sass
+++ b/app/assets/stylesheets/home.sass
@@ -1,10 +1,10 @@
-@import oh-styles
-
 .showcase
   padding-top: 20px
   padding-bottom: 30px
   width: 980px
-  margin-left: -20px
+  margin-left: -15px
+  padding-left: 5px
+  padding-right: 5px
 .billboard
   @include billboard-background-color
   color: white

--- a/app/assets/stylesheets/menu_bar.sass
+++ b/app/assets/stylesheets/menu_bar.sass
@@ -1,4 +1,0 @@
-// .select
-//   color: color-gradient($SECONDARY_YELLOW, 100) !important
-//   margin-bottom: 0px
-//   padding-bottom: 0px

--- a/app/assets/stylesheets/oh-styles.sass
+++ b/app/assets/stylesheets/oh-styles.sass
@@ -157,6 +157,27 @@
 
 ////////////////////////////////////////////////////////////////////
 //
+// Explore/* mixins
+
+@mixin explore-sidebar-icon-search-color
+  color: color-gradient($SECONDARY_MARINE_BLUE, 120)
+
+@mixin explore-sidebar-search-text-color
+  color: color-gradient($LIGHT_GRAY, 120)
+
+@mixin explore-people-signature-text-color
+  color: #e86d1f  // NOTE: non-OTWO color, needs to be udpated
+
+@mixin explore-people-tick-selected-colors
+  color: #2BB72B  // NOTE: non-OTWO color, needs to be udpated
+  background-color: #fff
+
+@mixin explore-people-tick-unselected-colors
+  color: #898989  // NOTE: non-OTWO color, needs to be udpated
+  background-color: #fff
+
+////////////////////////////////////////////////////////////////////
+//
 // Button mixins
 
 @mixin follow-button-colors
@@ -320,3 +341,86 @@
 
 @mixin vulnerabilities-disabled-text-color
   color: color-gradient($LIGHT_GRAY, 100)
+
+////////////////////////////////////////////////////////////////////
+//
+// Highcharts mixins
+
+@mixin vulnerabilities-high-severity-fill
+  fill: color-gradient($SECONDARY_MARINE_BLUE, 120)
+
+@mixin vulnerabilities-high-severity-stroke
+  stroke: color-gradient($SECONDARY_MARINE_BLUE, 120)
+
+@mixin vulnerabilities-medium-severity-fill
+  fill: color-gradient($SECONDARY_MARINE_BLUE, 80)
+
+@mixin vulnerabilities-medium-severity-stroke
+  stroke: color-gradient($SECONDARY_MARINE_BLUE, 80)
+
+@mixin vulnerabilities-low-severity-fill
+  fill: color-gradient($SECONDARY_MARINE_BLUE, 40)
+
+@mixin vulnerabilities-low-severity-stroke
+  stroke: color-gradient($SECONDARY_MARINE_BLUE, 40)
+
+@mixin vulnerabilities-unknown-severity-fill
+  fill: color-gradient($SECONDARY_SLATE_BLUE, 20)
+
+@mixin vulnerabilities-unknown-severity-stroke
+  stroke: color-gradient($SECONDARY_SLATE_BLUE, 20)
+
+@mixin vulnerabilities-high-severity-hover
+  fill: color-gradient($SECONDARY_MARINE_BLUE, 80)
+
+@mixin vulnerabilities-medium-severity-hover
+  fill: color-gradient($SECONDARY_MARINE_BLUE, 60)
+
+@mixin vulnerabilities-low-severity-hover
+  fill: color-gradient($SECONDARY_MARINE_BLUE, 20)
+
+@mixin vulnerabilities-unknown-severity-hover
+  fill: color-gradient($SECONDARY_SKY_BLUE, 20)
+
+@mixin projects-demographics-inactive-fill
+  fill: color-gradient($PRIMARY_DARK_GRAY, 60)
+
+@mixin projects-demographics-inactive-stroke
+  stroke: color-gradient($PRIMARY_DARK_GRAY, 60)
+
+@mixin projects-demographics-very-low-fill
+  fill: color-gradient($BLACK_DUCK_BLUE, 40)
+
+@mixin projects-demographics-very-low-stroke
+  stroke: color-gradient($BLACK_DUCK_BLUE, 40)
+
+@mixin projects-demographics-low-fill
+  fill: color-gradient($BLACK_DUCK_BLUE, 80)
+
+@mixin projects-demographics-low-stroke
+  stroke: color-gradient($BLACK_DUCK_BLUE, 80)
+
+@mixin projects-demographics-moderate-fill
+  fill: color-gradient($BLACK_DUCK_BLUE, 120)
+
+@mixin projects-demographics-moderate-stroke
+  stroke: color-gradient($BLACK_DUCK_BLUE, 120)
+
+@mixin projects-demographics-high-fill
+  fill: color-gradient($PRIMARY_PURPLE, 80)
+
+@mixin projects-demographics-high-stroke
+  stroke: color-gradient($PRIMARY_PURPLE, 80)
+
+@mixin projects-demographics-very-high-fill
+  fill: color-gradient($PRIMARY_PURPLE, 120)
+
+@mixin projects-demographics-very-high-stroke
+  stroke: color-gradient($PRIMARY_PURPLE, 120)
+
+@mixin projects-demographics-new-fill
+  fill: color-gradient($SECONDARY_ORANGE, 100)
+
+@mixin projects-demographics-new-stroke
+  stroke: color-gradient($SECONDARY_ORANGE, 100)
+

--- a/app/assets/stylesheets/organizations.sass
+++ b/app/assets/stylesheets/organizations.sass
@@ -1,5 +1,3 @@
-@import oh-colors
-
 .project_activity_margin_top
   :margin-top -8px
 

--- a/app/assets/stylesheets/page.sass
+++ b/app/assets/stylesheets/page.sass
@@ -1,7 +1,7 @@
 @import "base"
 
 body
-  background-color: white
+  background-color: #005272
   font-family: Roboto
   font-size: 1.3rem
   margin: 0
@@ -34,7 +34,7 @@ header
 #navbar-inner
   @include top-navbar-colors
   padding-top: 1px
-  margin-left: -3px
+  margin-left: 4px
   margin-right: 5px
   height: 42px
 
@@ -199,7 +199,7 @@ header
   margin-top: 0px
 
 .signature_color
-  color: #e86d1f
+  @include explore-people-signature-text-color
 
 .mezzo
   margin-top: -1px

--- a/app/assets/stylesheets/projects.sass
+++ b/app/assets/stylesheets/projects.sass
@@ -18,7 +18,7 @@ $pai_levels: (('very_high',0), ('high', 1), ('moderate', 2), ('low', 3), ('very_
     .#{$activity_level}_#{$postfix}
       @extend #{$activity_level}
       background-image: asset_url("projects/pai/pai-#{$dimension}px.png")
-      background-position: -#{$multiplier * $dimension}px 0
+      background-position: -#{($multiplier * $dimension)+($multiplier*2)}px 0
       background-repeat: no-repeat
       position: absolute
       top: 1rem

--- a/app/assets/stylesheets/search-dingus.sass
+++ b/app/assets/stylesheets/search-dingus.sass
@@ -1,5 +1,3 @@
-@import oh-colors
-
 #search-dingus
   @include site-well-color
   padding: 7px 0px

--- a/app/assets/stylesheets/sidebar.sass
+++ b/app/assets/stylesheets/sidebar.sass
@@ -1,5 +1,3 @@
-@import oh-styles
-
 .footer-navigation
   a
     @include site-link-color

--- a/app/assets/stylesheets/static_forms.sass
+++ b/app/assets/stylesheets/static_forms.sass
@@ -1,5 +1,3 @@
-// textarea
-//   color: #202020
 
 input
   &[type="text"], &[type="password"], &[type="datetime"], &[type="datetime-local"], &[type="date"], &[type="month"], &[type="time"], &[type="week"], &[type="number"], &[type="email"], &[type="url"], &[type="search"], &[type="tel"], &[type="color"]

--- a/app/assets/stylesheets/tags.sass
+++ b/app/assets/stylesheets/tags.sass
@@ -1,5 +1,3 @@
-@import oh-styles
-
 .tags
   .tag
     @include default-tag-colors

--- a/app/decorators/vulnerability/all_version_chart.rb
+++ b/app/decorators/vulnerability/all_version_chart.rb
@@ -12,6 +12,7 @@ class Vulnerability::AllVersionChart < Vulnerability::VersionChart
   def custom_chart_options
     @default_options[:chart][:renderTo] = 'vulnerability_all_version_chart'
     @default_options[:chart][:zoomType] = 'x'
+    @default_options[:chart][:styledMode] = true
     @default_options
   end
 end

--- a/app/decorators/vulnerability/version_chart.rb
+++ b/app/decorators/vulnerability/version_chart.rb
@@ -4,15 +4,10 @@
 class Vulnerability::VersionChart
   include ChartHelper
 
-  SEVERITY_LEGEND_COLORS = { secondary_marine_blue_120: '#183867',
-                             secondary_marine_blue_80: '#4b6b9a',
-                             secondary_marine_blue_40: '#a5b5cd',
-                             secondary_slate_blue_20: '#cce1e9' }.freeze
-
-  SEVERITY_LEGENDS = { high: [I18n.t('projects.vulnerabilities.severity.high'), SEVERITY_LEGEND_COLORS[:secondary_marine_blue_120]],
-                       medium: [I18n.t('projects.vulnerabilities.severity.medium'), SEVERITY_LEGEND_COLORS[:secondary_marine_blue_80]],
-                       low: [I18n.t('projects.vulnerabilities.severity.low'), SEVERITY_LEGEND_COLORS[:secondary_marine_blue_40]],
-                       unknown_severity: [I18n.t('projects.vulnerabilities.unknown_severity'), SEVERITY_LEGEND_COLORS[:secondary_slate_blue_20]] }.freeze
+  SEVERITY_LEGENDS = { high: [I18n.t('projects.vulnerabilities.severity.high')],
+                       medium: [I18n.t('projects.vulnerabilities.severity.medium')],
+                       low: [I18n.t('projects.vulnerabilities.severity.low')],
+                       unknown_severity: [I18n.t('projects.vulnerabilities.unknown_severity')] }.freeze
 
   def initialize(release_history)
     @release_history = release_history
@@ -33,7 +28,7 @@ class Vulnerability::VersionChart
   def series
     SEVERITY_LEGENDS.keys.each_with_index do |level, index|
       legend = SEVERITY_LEGENDS[level]
-      @default_options[:series][index] = { name: legend[0], color: legend[1],
+      @default_options[:series][index] = { name: legend[0],
                                            data: vulnerabilities_count_by_severity(level.to_s) }
     end
     @default_options

--- a/app/views/edits/_edit.html.haml
+++ b/app/views/edits/_edit.html.haml
@@ -8,7 +8,11 @@
       .edit_actions
         .undo_block= render partial: 'undo_block', locals: { edit: edit }
       .in_avatar.clear
-        = avatar_for(edit.account)
+        - if edit.account.name == 'The Ohloh Hamster'
+          %p.twitter-text
+            &nbsp;OH&nbsp;
+        - else
+          = avatar_for(edit.account)
       .inside
         %p.strong.nomargin{ class: edit_title_class(edit) }
           = link_to edit.id, show_edit_path(edit), class: 'show_edit_btn', remote: true,

--- a/config/charting/project_vulnerability_version.yml
+++ b/config/charting/project_vulnerability_version.yml
@@ -2,6 +2,7 @@ chart:
   type: 'column'
   renderTo: 'vulnerability_version_chart'
   backgroundColor: 'transparent'
+  styledMode: true
 credits:
   enabled: false
 title:


### PR DESCRIPTION
This PR addresses the OTWO color updates to 'explore#people',
and other minor updates regarding the mockup on OTWO-5758.

This PR also addresses the background margin colors on the home 
and projects pages, vulnerability chart hover colors/issues, using
text & css to replace the old colored 'OH' avatar, and other minor
updates.