### PR TITLE
OTWO 5761 - Update the Explore Organization page

### DIFF
--- a/app/assets/stylesheets/dynamic.sass
+++ b/app/assets/stylesheets/dynamic.sass
@@ -18,7 +18,7 @@ ul.select_people
   li.people
     a
       @include menu_links
-ul.select_tools
+ul
   li.tools
-    a
+    a.select
       @include menu_links

--- a/app/assets/stylesheets/oh-colors.sass
+++ b/app/assets/stylesheets/oh-colors.sass
@@ -97,11 +97,9 @@ $OH_COLORS: ( -1: $c1, -2: $c2, -3: $c3, -4: $c4, 1: $m1, 2: $m2, 3: $m3, 4: $m4
 // DEPRECATED COLORS
 
 $primary-gray-40: #c0bebe
-$secondary-blue: #00639c
 $secondary-blue-20: #c9cdd9
 $secondary-blue-40: #3ab7ff
 $secondary-blue-80: #0088d7
-$secondary-blue-darker: #00314e
 $secondary-red: #ef4923
 $primary-blue-darker: color-gradient($BLACK_DUCK_BLUE, 80)
 $primary-blue: color-gradient($SECONDARY_MARINE_BLUE, 80)

--- a/app/assets/stylesheets/organizations.sass
+++ b/app/assets/stylesheets/organizations.sass
@@ -1,5 +1,5 @@
 .project_activity_margin_top
-  :margin-top -8px
+  margin-top: -8px
 
 tbody.portfolio-projects-table
   td
@@ -7,26 +7,26 @@ tbody.portfolio-projects-table
       width: auto !important
   tr:nth-child(odd), tr:nth-child(even)
     td
-      :background-color white
+      background-color: white
   tr:nth-child(3n+1)
     td
-      :border-top solid 1px black !important
-      :border-bottom solid 1px black !important
+      border-top: solid 1px black !important
+      border-bottom: solid 1px black !important
   tr:nth-child(6n+1), tr:nth-child(6n+2), tr:nth-child(6n+3)
     td
-      :background-color #f9f9f9 !important
+      background-color: #f9f9f9 !important
 
 .org_project_rating
   margin-left: 18px
   display: block
 
 #dingus-row td
-  :background-color color-gradient($LIGHT_GRAY, 20)
-  :padding 0px
-  :min-height 5px
-  :border-top 0px none
-  :border-top-right-radius 8px
-  :border-top-left-radius 8px
+  background-color: color-gradient($LIGHT_GRAY, 20)
+  padding: 0px
+  min-height: 5px
+  border-top: 0px none
+  border-top-right-radius: 8px
+  border-top-left-radius: 8px
 
 .language_name
   line-height: 28px
@@ -116,7 +116,7 @@ tbody.portfolio-projects-table
     font-style: normal !important
     font-size: 11px
   .header
-    background-color: $secondary_blue !important
+    background-color: color-gradient($SECONDARY_SLATE_BLUE, 120) !important
     -webkit-print-color-adjust: exact
     height: 33px
     color: white !important
@@ -150,17 +150,17 @@ tbody.portfolio-projects-table
         margin-top: 17px
     .count
       font-size: 22px
-      color: $secondary-blue-darker
+      color: color-gradient($SECONDARY_SLATE_BLUE, 120)
       text-align: center
       a
-        color: $secondary-blue_darker
+        color: color-gradient($SECONDARY_SLATE_BLUE, 120)
     .portfolio_label
       font-size: 12px
-      color: $secondary-blue-darker
+      color: color-gradient($SECONDARY_SLATE_BLUE, 120)
       white-space: nowrap
       margin-top: -5px
   .footer_line
-    background-color: $secondary-blue-darker
+    background-color: color-gradient($SECONDARY_SLATE_BLUE, 120)
     font-size: 1px
     height: 7px !important
   .bottom_links

--- a/app/assets/stylesheets/orgs.sass
+++ b/app/assets/stylesheets/orgs.sass
@@ -35,7 +35,7 @@
       margin-left: 5px
     .col-md-9 a
       font-weight: bold
-      color: #369
+      color: color-gradient($SECONDARY_SLATE_BLUE, 120)
       font-size: 15px
 
   #orgs_by_30_days_volume
@@ -57,7 +57,7 @@
         margin: 5px 0px 0px 0px
       .col-md-9 a
         font-weight: bold
-        color: #369
+        color: color-gradient($SECONDARY_SLATE_BLUE, 120)
         font-size: 15px
     .row#active-org-timestamp
       font-size: 9px
@@ -69,6 +69,9 @@
       width: 220px
       height: 80px
       margin: 0 auto
+      .highcharts-color-0
+        fill: color-gradient($SECONDARY_SLATE_BLUE, 120)
+        stroke: color-gradient($SECONDARY_SLATE_BLUE, 120)
 
   #org_filter_no_result
     width: 620px
@@ -86,6 +89,6 @@
     border-radius: 0
 
     #progress-bar
-      background-color: #428bca
+      background-color: color-gradient($SECONDARY_SLATE_BLUE, 120)
       color: white
       padding: 0 0 0 3px

--- a/app/assets/stylesheets/page.sass
+++ b/app/assets/stylesheets/page.sass
@@ -43,7 +43,6 @@ header
     @include site-separator-color
 
 #project_container
-  width: 1240px
   background-color: white
   margin: 0 auto
   padding: 10px 10px 0 10px


### PR DESCRIPTION
This PR updates the explore#organization page regarding the 2019 OH Style Guide (and mock-ups in OTWO-5758).

This PR also addresses 1) highlighting the 'Tools' selection in the menu bar and 2) full-width layout for projects#show and related pages (projects#security, etc...) as described in the bullet points of OTWO-5924.