### PR TITLE
OTWO-5930: Update CSS for Account Show page

### DIFF
--- a/app/assets/stylesheets/accounts/show.sass
+++ b/app/assets/stylesheets/accounts/show.sass
@@ -32,7 +32,7 @@
   .info
     margin-top: 3px
   h1
-    color: $primary-blue-darker
+    @include site-link-color
     width: 350px
   .social-connect
     padding-top: 5px

--- a/app/assets/stylesheets/charts.sass
+++ b/app/assets/stylesheets/charts.sass
@@ -347,3 +347,53 @@
   .highcharts-legend-series-active .highcharts-data-labels:not(.highcharts-series-hover)
     opacity: 1.0
 
+#project_contributions
+  .highcharts-point.highcharts-color-0,
+  .highcharts-legend-item.highcharts-color-0 .highcharts-point,
+  .highcharts-tooltip .highcharts-color-0
+    @include project-contributions-color-0-fill
+
+  .highcharts-point.highcharts-color-1,
+  .highcharts-legend-item.highcharts-color-1 .highcharts-point,
+  .highcharts-tooltip .highcharts-color-1
+    @include project-contributions-color-1-fill
+
+  .highcharts-point.highcharts-color-2,
+  .highcharts-legend-item.highcharts-color-2 .highcharts-point,
+  .highcharts-tooltip .highcharts-color-2
+    @include project-contributions-color-2-fill
+
+  .highcharts-point.highcharts-color-3,
+  .highcharts-legend-item.highcharts-color-3 .highcharts-point,
+  .highcharts-tooltip .highcharts-color-3
+    @include project-contributions-color-3-fill
+
+  .highcharts-point.highcharts-color-4,
+  .highcharts-legend-item.highcharts-color-4 .highcharts-point,
+  .highcharts-tooltip .highcharts-color-4
+    @include project-contributions-color-4-fill
+
+  .highcharts-point.highcharts-color-5,
+  .highcharts-legend-item.highcharts-color-5 .highcharts-point,
+  .highcharts-tooltip .highcharts-color-5
+    @include project-contributions-color-5-fill
+
+  .highcharts-point.highcharts-color-6,
+  .highcharts-legend-item.highcharts-color-6 .highcharts-point,
+  .highcharts-tooltip .highcharts-color-6
+    @include project-contributions-color-6-fill
+
+  .highcharts-point.highcharts-color-7,
+  .highcharts-legend-item.highcharts-color-7 .highcharts-point,
+  .highcharts-tooltip .highcharts-color-7
+    @include project-contributions-color-7-fill
+
+  .highcharts-point.highcharts-color-8,
+  .highcharts-legend-item.highcharts-color-8 .highcharts-point,
+  .highcharts-tooltip .highcharts-color-8
+    @include project-contributions-color-8-fill
+
+  .highcharts-point.highcharts-color-9,
+  .highcharts-legend-item.highcharts-color-9 .highcharts-point,
+  .highcharts-tooltip .highcharts-color-9
+    @include project-contributions-color-9-fill

--- a/app/assets/stylesheets/oh-colors.sass
+++ b/app/assets/stylesheets/oh-colors.sass
@@ -96,13 +96,10 @@ $OH_COLORS: ( -1: $c1, -2: $c2, -3: $c3, -4: $c4, 1: $m1, 2: $m2, 3: $m3, 4: $m4
 //
 // DEPRECATED COLORS
 
-$primary-gray-40: #c0bebe
 $secondary-blue-20: #c9cdd9
 $secondary-blue-40: #3ab7ff
 $secondary-blue-80: #0088d7
 $secondary-red: #ef4923
-$primary-blue-darker: color-gradient($BLACK_DUCK_BLUE, 80)
-$primary-blue: color-gradient($SECONDARY_MARINE_BLUE, 80)
 $primary-blue-20: color-gradient($SECONDARY_SKY_BLUE, 20)
 $orange: #ff7600
 $soft_gray: #777

--- a/app/assets/stylesheets/oh-styles.sass
+++ b/app/assets/stylesheets/oh-styles.sass
@@ -43,6 +43,9 @@
 @mixin site-separator-background-color
   background-color: color-gradient($PRIMARY_DARK_GRAY, 60)
 
+@mixin ie-not-supported-text-color
+  color: color-gradient($WEB_RED, 100)
+
 ////////////////////////////////////////////////////////////////////
 //
 // Header/menu-bar mixins
@@ -72,17 +75,17 @@
   color: color-gradient($SECONDARY_YELLOW, 100)  !important
 
 @mixin global-top-search-colors
-  border-color: color-gradient($SECONDARY_LIGHT_PURPLE, 100) !important
+  border-color: color-gradient($LIGHT_GRAY, 120) !important
   color: color-gradient($LIGHT_GRAY, 120) !important
   &:-moz-placeholder
-    color:    color-gradient($LIGHT_GRAY, 100)
+    color:    color-gradient($LIGHT_GRAY, 120)
     font-style: italic
     opacity:  1
   &:-ms-input-placeholder
-    color:    color-gradient($LIGHT_GRAY, 100)
+    color:    color-gradient($LIGHT_GRAY, 120)
     font-style: italic
   &::-webkit-input-placeholder
-    color:    color-gradient($LIGHT_GRAY, 100)
+    color:    color-gradient($LIGHT_GRAY, 120)
     font-style: italic
 
 @mixin global-top-search-hover-background-color
@@ -91,17 +94,27 @@
 @mixin global-top-search-hover-border-color
   border-color: color-gradient($SECONDARY_MARINE_BLUE, 60) !important
 
+@mixin global-top-search-icon-color
+  color: white !important
+
+@mixin search-dropdown-link-color
+  color: color-gradient($SECONDARY_SLATE_BLUE, 120)
+
+@mixin search-dropdown-link-hover-colors
+  background-color: color-gradient($SECONDARY_MARINE_BLUE, 100)
+  color: white
+
 ////////////////////////////////////////////////////////////////////
 //
 // Footer/bottom-nav mixins
 
 @mixin bottom-nav-active-colors
-  color: color-gradient($SECONDARY_SLATE_BLUE, 100)
-  background-color: color-gradient($SECTION_BACKGROUND_BLUE, 0)
-  border-left: 3px solid color-gradient($SECONDARY_SLATE_BLUE, 100)
+  color: color-gradient($SECONDARY_MARINE_BLUE, 100)
+  background-color: color-gradient($SECONDARY_MARINE_BLUE, 20)
+  border-left: 3px solid color-gradient($SECONDARY_MARINE_BLUE, 100)
 
 @mixin bottom-nav-hover-colors
-  color: color-gradient($SECONDARY_SLATE_BLUE, 100)
+  color: color-gradient($SECONDARY_MARINE_BLUE, 100)
   background-color: color-gradient($LIGHT_GRAY, 20)
   border-left: 3px solid color-gradient($PRIMARY_DARK_GRAY, 100)
 
@@ -253,13 +266,21 @@
     border-color: color-gradient($SECONDARY_ORANGE, 40) !important
 
 @mixin info-button-colors
-  background-color: $primary-blue-darker !important
-  border-color: $primary-blue-darker !important
+  color: white
+  background-color: color-gradient($SECONDARY_MARINE_BLUE, 120) !important
+  border-color: color-gradient($SECONDARY_MARINE_BLUE, 120)
   &:hover
-    background-color: $primary-blue !important
-    border-color: $primary-blue !important
+    background-color: color-gradient($SECONDARY_MARINE_BLUE, 80) !important
+    border-color: color-gradient($SECONDARY_MARINE_BLUE, 80) !important
   &.no-border:hover
-    border-color: $primary-blue !important
+    border-color: color-gradient($SECONDARY_MARINE_BLUE, 80) !important
+  &.disabled, &[disabled]
+    background-color: color-gradient($SECONDARY_MARINE_BLUE, 40) !important
+    border-color: color-gradient($SECONDARY_MARINE_BLUE, 40) !important
+
+@mixin search-button-hover-colors
+  background-color: color-gradient($SECONDARY_SLATE_BLUE, 120) !important
+  border-color: color-gradient($SECONDARY_SLATE_BLUE, 120) !important
 
 ////////////////////////////////////////////////////////////////////
 //
@@ -314,7 +335,7 @@
   background-color: color-gradient($LIGHT_GRAY, 100) !important
 
 @mixin analysis-timestamp-color
-  color: color-gradient($LIGHT_GRAY, 100)
+  color: color-gradient($LIGHT_GRAY, 120)
 
 @mixin licenses-permitted-color
   color: color-gradient($SECONDARY_FOREST_GREEN, 120)
@@ -425,3 +446,32 @@
 @mixin projects-demographics-new-stroke
   stroke: color-gradient($SECONDARY_ORANGE, 100)
 
+@mixin project-contributions-color-0-fill
+  fill: color-gradient($SECONDARY_SKY_BLUE, 20) 
+
+@mixin project-contributions-color-1-fill
+  fill: color-gradient($SECONDARY_SKY_BLUE, 40)
+
+@mixin project-contributions-color-2-fill
+  fill: color-gradient($SECONDARY_SKY_BLUE, 60)
+
+@mixin project-contributions-color-3-fill
+  fill: color-gradient($SECONDARY_SKY_BLUE, 80)
+
+@mixin project-contributions-color-4-fill
+  fill: color-gradient($SECONDARY_SKY_BLUE, 100)
+
+@mixin project-contributions-color-5-fill
+  fill: color-gradient($SECONDARY_SKY_BLUE, 120)
+
+@mixin project-contributions-color-6-fill
+  fill: color-gradient($SECONDARY_SKY_BLUE, 20)
+
+@mixin project-contributions-color-7-fill
+  fill: color-gradient($SECONDARY_SKY_BLUE, 40)
+
+@mixin project-contributions-color-8-fill
+  fill: color-gradient($SECONDARY_SKY_BLUE, 60)
+
+@mixin project-contributions-color-9-fill
+  fill: color-gradient($SECONDARY_SKY_BLUE, 80)

--- a/app/assets/stylesheets/search-dingus.sass
+++ b/app/assets/stylesheets/search-dingus.sass
@@ -49,12 +49,11 @@
     li
       display: inline
       a
-        color: color-gradient($SECONDARY_SLATE_BLUE, 120)
+        @include search-dropdown-link-color
         font-size: 14px
         text-transform: none
         &:hover
-          background-color: color-gradient($SECONDARY_MARINE_BLUE, 100)
-          color: #fff
+          @include search-dropdown-link-hover-colors
   .btn-small
     font-size: 14px
     border-width: 2px !important
@@ -63,13 +62,13 @@
       font-weight: 100
       text-transform: none
     &:hover
-      background-color: color-gradient($SECONDARY_SLATE_BLUE, 120) !important
-      border-color: color-gradient($SECONDARY_SLATE_BLUE, 120) !important
+      @include search-button-hover-colors
 
 .global_top_search
   height: 18px !important
   @include global-top-search-colors
 
 .global_top_search_icon
-  color: rgba(82, 168, 236, 0.8) !important
+  @include global-top-search-icon-color
+  padding-bottom: 5px
   font-size: 18px

--- a/app/assets/stylesheets/streamgraph.sass
+++ b/app/assets/stylesheets/streamgraph.sass
@@ -22,10 +22,10 @@
     height: 300px !important
 
 .streamgraph_IE_not_supported
+  @include ie-not-supported-text-color
   width: 900px !important
   background: asset_url('sample_streamgraph.png') no-repeat !important
   font-weight: bold
-  color: red
 
 #streamgraph_legend
   width: 150px
@@ -37,10 +37,13 @@
   padding-top: 5px
 
 #streamgraph_legend
+  div
+    dislplay: inline-block
   p
+    @include site-link-color
     padding-left: 10px
     margin: 0 0 -2px 0
-    color: #3e576f
+    dislplay: inline
 
 .streamgraph_legend_color
   width: 16px
@@ -49,6 +52,7 @@
   float: left
   margin: 4px 4px 0 4px
   border-radius: 3px
+  clear: left
 
 .full
   .background-watermark

--- a/app/views/accounts/show/_header.html.haml
+++ b/app/views/accounts/show/_header.html.haml
@@ -18,8 +18,7 @@
         - if my_account?(@account) || current_user_is_admin?
           - if @account.location.present?
             %span.seperator &nbsp;|&nbsp;
-          = link_to settings_account_path(@account) do
-            %i.icon-cogs!=  t('.account_settings')
+          != link_to bootstrap_icon('icon-cogs', t('.account.settings')), settings_account_path(@account)
         - if current_user_is_admin?
           |
           = link_to bootstrap_icon('icon-legal', t('.view_job')), admin_account_vita_jobs_path(@account)

--- a/app/views/shared/_search.html.haml
+++ b/app/views/shared/_search.html.haml
@@ -21,3 +21,6 @@
         %input.search.text.global_top_search{ type: :text, name: 'query', placeholder: t('shared.search.search_text'),
         value: global_search_param, autocomplete: 'off' }
         %input.search.hidden{ type: 'hidden', name: 'search_type', id: 'search_type', value: 'projects' }
+        %button.submit.no_padding{ type: 'submit' }
+          .icon-search.global_top_search_icon
+

--- a/config/charting/defaults.yml
+++ b/config/charting/defaults.yml
@@ -2,13 +2,6 @@ highchart: true
 chart:
   borderRadius: 5
   type: 'column'
-colors:
-  - '#49baf2'
-  - '#527acc'
-  - '#5353a6'
-  - '#5e4d80'
-  - '#503d59'
-  - '#332933'
 title:
   text: ''
 plotOptions:


### PR DESCRIPTION
This PR addresses the updates re the new Ohloh UI Trade Dress to the `accounts#show` page referenced in the [2019 OH Style Guide ](https://sig-confluence.internal.synopsys.com/pages/viewpage.action?spaceKey=O2&title=2019+OH+Style+Guide)

This PR highlights the color updates to the `commits_by_project` chart, as well as addressing some global color updates to such elements as the timestamp signature, search box controls, and footer navigation colors.  These are also referenced in the 2019 OH Style Guide.