### PR TITLE
OTWO-5765: Update CSS for the Project Commits pages

### DIFF
--- a/app/assets/stylesheets/base.sass
+++ b/app/assets/stylesheets/base.sass
@@ -16,12 +16,17 @@
 =link_blue
   @include site-link-color
 
+// font awesome custom styles
+#commits_index_page,
+#commits_summary_page
+  [class^="icon-"], [class*=" icon-"]
+    font-family: Roboto !important
+
 body
   text-rendering: optimizeLegibility
   a
     @include site-link-color
   
-
 .hidden
   display: none
 
@@ -95,7 +100,7 @@ h1, h2, h3, h4, h5, h6, p, li, dd, dt,span,a,abbr,td,th
   &.soft
     @include soft-font-color
   &.date
-    color: #777
+    @include site-link-color
 
 .col
   h5, h6, p, dl, ul, ol, code

--- a/app/assets/stylesheets/charts.sass
+++ b/app/assets/stylesheets/charts.sass
@@ -397,3 +397,12 @@
   .highcharts-legend-item.highcharts-color-9 .highcharts-point,
   .highcharts-tooltip .highcharts-color-9
     @include project-contributions-color-9-fill
+
+#code_analysis_chart
+  .highcharts-graph
+    @include code-analysis-chart-color-0-stroke
+
+#committer_history_chart
+  .highcharts-graph
+    @include code-analysis-chart-color-0-stroke
+

--- a/app/assets/stylesheets/fontawesome_icons.sass
+++ b/app/assets/stylesheets/fontawesome_icons.sass
@@ -1,5 +1,5 @@
 [class^="icon-"], [class*=" icon-"]
-  font-family: FontAwesome
+  font-family: FontAwesome !important
   font-weight: normal
   font-style: normal
   text-decoration: inherit

--- a/app/assets/stylesheets/oh-colors.sass
+++ b/app/assets/stylesheets/oh-colors.sass
@@ -102,6 +102,5 @@ $secondary-blue-80: #0088d7
 $secondary-red: #ef4923
 $primary-blue-20: color-gradient($SECONDARY_SKY_BLUE, 20)
 $orange: #ff7600
-$soft_gray: #777
 $c2_light: #D5E3E9
 $c3_light: #EBECD3

--- a/app/assets/stylesheets/oh-styles.sass
+++ b/app/assets/stylesheets/oh-styles.sass
@@ -184,6 +184,9 @@
 @mixin infographic-box-header-background-color
   background-color: color-gradient($SECONDARY_SLATE_BLUE, 120) !important
 
+@mixin projects-summary-analysis-in-progress-color
+  color: color-gradient($LIGHT_GRAY, 120)
+
 @mixin projects-summary-projects-name-background-color
   background-color: color-gradient($SECONDARY_ORANGE, 100)
 
@@ -322,9 +325,6 @@
 
 @mixin static-forms-text-color
   color: color-gradient($PRIMARY_DARK_GRAY, 100)
-
-@mixin static-forms-border-color
-  border-color: color-gradient($SECONDARY_SLATE_BLUE, 120)
 
 @mixin chzn-container-background-color
   background: color-gradient($SECONDARY_SLATE_BLUE, 120)
@@ -509,3 +509,7 @@
 
 @mixin project-contributions-color-9-fill
   fill: color-gradient($SECONDARY_SKY_BLUE, 80)
+
+@mixin code-analysis-chart-color-0-stroke
+  stroke: color-gradient($SECONDARY_SLATE_BLUE, 120)
+

--- a/app/assets/stylesheets/project_summary.sass
+++ b/app/assets/stylesheets/project_summary.sass
@@ -49,7 +49,7 @@ ul#factoids
         :line-height 13px
 
 .analysis_in_progress
-  :color $soft_gray
+  @include projects-summary-analysis-in-progress-color
 
 #similar_projects
   table

--- a/app/views/shared/search_dingus/_commits_or_contributor_search.html.haml
+++ b/app/views/shared/search_dingus/_commits_or_contributor_search.html.haml
@@ -17,7 +17,7 @@
         %label #{t('shared.search_dingus.search_bar.search_text')} &nbsp;
         = text_field_tag :query, params[:query]
         = hidden_field_tag :time_span, params[:time_span]
-        %button.btn{ type: 'Submit' }
+        %button.btn.btn-refresh{ type: 'Submit' }
           %i.icon-refresh
       - if type == :contributions
         = render 'shared/search_dingus/sort', sort_context: :contributions, filter_type: nil


### PR DESCRIPTION
This PR addresses updating the colors defined for the `commits#index` and `commits#summary` pages, with respect to the new UI Trade Dress. 

A few issues are still open before squashing and merging to the feature branch:
1) color updates for the range buttons on the Commits Per Month chart
2) color definition for the Commits Per Month chart
3) should the "Month Recent Commits" heading be revised to "Most Recent Commits"?