### PR TITLE
OTWO-6438 NullDB to for asset compilation w/o DB

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -106,7 +106,8 @@ group :development, :test do
   gem 'teaspoon-jasmine'
 end
 
-group :production do
+group :production, :staging do
+  gem 'activerecord-nulldb-adapter', require: false
 end
 
 group :development, :staging do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,8 @@ GEM
       activemodel (= 4.2.11.1)
       activesupport (= 4.2.11.1)
       arel (~> 6.0)
+    activerecord-nulldb-adapter (0.4.0)
+      activerecord (>= 2.0.0)
     activerecord-postgres-dump-schemas (0.1.0)
       activerecord (< 5)
       railties (< 5)
@@ -573,6 +575,7 @@ PLATFORMS
 
 DEPENDENCIES
   activeadmin (= 1.0.0)
+  activerecord-nulldb-adapter
   activerecord-postgres-dump-schemas
   airbrake (~> 5.5)
   aws-sdk (~> 2.3)
@@ -671,4 +674,4 @@ DEPENDENCIES
   will_paginate-bootstrap
 
 BUNDLED WITH
-   2.2.3
+   1.17.3


### PR DESCRIPTION
* rake assets:precompile loads the initializers.
* Initializers require app/lib which connects to the DB.
* We want to compile assets in base Docker image.
* Use DATABASE_URL=nulldb://user:pass@127.0.0.1/dbname
* Downgraded bundler version to accurately reflect rails 4 deps.