### PR TITLE
Fix install issues with latest nokogiri

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN chown -R serv-deployer:serv-deployer $APP_HOME
 USER serv-deployer
 RUN cd $APP_HOME \
   && gem install bundler:1.17.3 \
+  && gem install nokogiri -v 1.12.5 \
   && gem install rails -v 4.2.11.1 \
   && bundle install \
   && RAILS_ENV=production DATABASE_URL=nulldb://user:pass@127.0.0.1/dbname bundle exec rake assets:precompile


### PR DESCRIPTION
nokogiri is a rails dependency and 1.13.0 released 6 days ago.
rails attempts to install latest nokogiri and fails with:
```
  ERROR:  While executing gem ... (Gem::RemoteFetcher::FetchError)
  bad response Forbidden 403 (...nokogiri-1.13.0-x64-unknown.gemspec.rz)
```
Issue only affects Rails 4.
Undo this commit when the issue is resolved.