### PR TITLE
Cleanup unused test & development gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,6 @@ gem 'will_paginate-bootstrap'
 
 group :development do
   gem 'better_errors'
-  gem 'binding_of_caller'
   gem 'bootsnap', '~> 1.10.3', require: false
   gem 'capistrano'
   gem 'capistrano-faster-assets'
@@ -64,27 +63,16 @@ group :development do
   gem 'capistrano-rbenv', '~> 2.0'
   gem 'capistrano-sidekiq'
   gem 'ed25519'
-  gem 'guard'
-  gem 'guard-coffeescript'
-  gem 'guard-haml_lint'
-  gem 'guard-livereload', '~> 2.5', '>= 2.5.2', require: false
-  gem 'guard-rubocop'
-  gem 'meta_request'
-  # gem 'quiet_assets'
 end
 
 group :test do
-  gem 'flog'
   gem 'haml_lint', '~> 0.21'
-  gem 'm', '~> 1.5.0'
   gem 'minitest-rails'
   gem 'minitest-spec-rails'
   gem 'mocha'
   gem 'rails-controller-testing'
-  gem 'ruby_parser'
   gem 'simplecov'
   gem 'simplecov-rcov'
-  gem 'spring'
   gem 'timecop'
   gem 'vcr'
   gem 'webmock'
@@ -92,19 +80,9 @@ end
 
 group :development, :test do
   gem 'byebug'
-  gem 'capybara'
   gem 'database_cleaner'
   gem 'factory_bot_rails'
   gem 'faker'
-  gem 'pry-byebug'
-  gem 'pry-rails'
-  gem 'rails-erd'
-  gem 'rb-readline', '~> 0.5.5'
-  gem 'rubocop-faker'
-  gem 'selenium-webdriver'
-  gem 'spinach'
-  gem 'spinach-console-reporter'
-  gem 'teaspoon-jasmine'
 end
 
 group :production, :staging do

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ gem 'clearance'
 gem 'coffee-rails'
 gem 'coffee-script-source', '~>1.8.0'
 gem 'datadog_api_client'
-gem 'ddtrace', require: 'ddtrace/auto_instrument'
 gem 'doorkeeper', '~> 4.4.0'
 gem 'dotenv-rails'
 gem 'execjs'
@@ -87,6 +86,7 @@ end
 
 group :production, :staging do
   gem 'activerecord-nulldb-adapter', require: false
+  gem 'ddtrace', require: 'ddtrace/auto_instrument'
 end
 
 group :development, :staging do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,8 +94,6 @@ GEM
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
-    binding_of_caller (1.0.0)
-      debug_inspector (>= 0.0.1)
     bootsnap (1.10.3)
       msgpack (~> 1.2)
     brakeman (5.2.0)
@@ -128,17 +126,6 @@ GEM
       capistrano (>= 3.9.0)
       capistrano-bundler
       sidekiq (>= 6.0)
-    capybara (3.36.0)
-      addressable
-      matrix
-      mini_mime (>= 0.1.3)
-      nokogiri (~> 1.8)
-      rack (>= 1.6.0)
-      rack-test (>= 0.6.3)
-      regexp_parser (>= 1.5, < 3.0)
-      xpath (~> 3.2)
-    childprocess (4.1.0)
-    choice (0.2.0)
     chronic (0.10.2)
     clearance (2.5.0)
       actionmailer (>= 5.0)
@@ -157,7 +144,6 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.8.0)
-    colorize (0.8.1)
     commonjs (0.2.7)
     concurrent-ruby (1.1.9)
     connection_pool (2.2.5)
@@ -176,7 +162,6 @@ GEM
       debase-ruby_core_source (= 0.10.12)
       msgpack
     debase-ruby_core_source (0.10.12)
-    debug_inspector (1.1.0)
     docile (1.4.0)
     doorkeeper (4.4.3)
       railties (>= 4.2)
@@ -185,16 +170,12 @@ GEM
       dotenv (= 2.7.6)
       railties (>= 3.2)
     ed25519 (1.2.4)
-    em-websocket (0.5.3)
-      eventmachine (>= 0.12.9)
-      http_parser.rb (~> 0)
     email_validator (2.2.3)
       activemodel
     erubi (1.10.0)
     erubis (2.7.0)
     ethon (0.15.0)
       ffi (>= 1.15.0)
-    eventmachine (1.2.7)
     execjs (2.8.1)
     factory_bot (6.2.0)
       activesupport (>= 5.0.0)
@@ -210,45 +191,13 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
-    flog (4.6.4)
-      path_expander (~> 1.0)
-      ruby_parser (~> 3.1, > 3.1.0)
-      sexp_processor (~> 4.8)
     font-awesome-rails (4.7.0.7)
       railties (>= 3.2, < 7)
-    formatador (0.3.0)
     formtastic (4.0.0)
       actionpack (>= 5.2.0)
     formtastic_i18n (0.7.0)
-    gherkin-ruby (0.3.2)
     globalid (1.0.0)
       activesupport (>= 5.0)
-    guard (2.18.0)
-      formatador (>= 0.2.4)
-      listen (>= 2.7, < 4.0)
-      lumberjack (>= 1.0.12, < 2.0)
-      nenv (~> 0.1)
-      notiffany (~> 0.0)
-      pry (>= 0.13.0)
-      shellany (~> 0.0)
-      thor (>= 0.18.1)
-    guard-coffeescript (2.0.1)
-      coffee-script (>= 2.2.0)
-      guard (>= 2.1.0)
-      guard-compat (~> 1.1)
-    guard-compat (1.2.1)
-    guard-haml_lint (1.1.0)
-      guard (~> 2.2)
-      guard-compat (~> 1.2)
-      haml_lint (>= 0.30.0)
-    guard-livereload (2.5.2)
-      em-websocket (~> 0.5)
-      guard (~> 2.8)
-      guard-compat (~> 1.0)
-      multi_json (~> 1.8)
-    guard-rubocop (1.5.0)
-      guard (~> 2.0)
-      rubocop (< 2.0)
     haml (5.2.2)
       temple (>= 0.8.0)
       tilt
@@ -273,7 +222,6 @@ GEM
       haml (>= 4.0, < 6)
       nokogiri (>= 1.6.0)
       ruby_parser (~> 3.5)
-    http_parser.rb (0.8.0)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     inherited_resources (1.13.1)
@@ -318,23 +266,12 @@ GEM
       railties (>= 3.2)
     libv8 (3.16.14.19)
     libv8 (3.16.14.19-x86_64-linux)
-    listen (3.7.0)
-      rb-fsevent (~> 0.10, >= 0.10.3)
-      rb-inotify (~> 0.9, >= 0.9.10)
     loofah (2.14.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    lumberjack (1.2.8)
-    m (1.5.1)
-      method_source (>= 0.6.7)
-      rake (>= 0.9.2.2)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
-    matrix (0.4.2)
-    meta_request (0.7.3)
-      rack-contrib (>= 1.1, < 3)
-      railties (>= 3.0.0, < 7)
     method_source (1.0.0)
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
@@ -353,8 +290,6 @@ GEM
       railties (>= 4.1)
     mocha (1.13.0)
     msgpack (1.4.2)
-    multi_json (1.15.0)
-    nenv (0.3.0)
     net-scp (3.0.0)
       net-ssh (>= 2.6.5, < 7.0.0)
     net-ssh (6.1.0)
@@ -363,9 +298,6 @@ GEM
       racc (~> 1.4)
     nokogiri (1.11.7-x86_64-linux)
       racc (~> 1.4)
-    notiffany (0.1.3)
-      nenv (~> 0.1)
-      shellany (~> 0.0)
     oh_delegator (0.1.0)
     ohloh_scm (2.4.0)
       nokogiri (~> 1.8, >= 1.8.1)
@@ -381,23 +313,12 @@ GEM
     parallel (1.21.0)
     parser (3.1.0.0)
       ast (~> 2.4.1)
-    path_expander (1.1.0)
     pg (0.20.0)
     posix-spawn (0.3.15)
     power_assert (2.0.1)
-    pry (0.13.1)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
-    pry-byebug (3.9.0)
-      byebug (~> 11.0)
-      pry (~> 0.13.0)
-    pry-rails (0.3.9)
-      pry (>= 0.10.4)
     public_suffix (4.0.6)
     racc (1.6.0)
     rack (2.2.3)
-    rack-contrib (2.3.0)
-      rack (~> 2.0)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.6.3)
@@ -420,11 +341,6 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-erd (1.6.1)
-      activerecord (>= 4.2)
-      activesupport (>= 4.2)
-      choice (~> 0.2.0)
-      ruby-graphviz (~> 1.2)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
     railties (5.2.6.3)
@@ -435,10 +351,6 @@ GEM
       thor (>= 0.19.0, < 2.0)
     rainbow (3.0.0)
     rake (13.0.6)
-    rb-fsevent (0.11.0)
-    rb-inotify (0.10.1)
-      ffi (~> 1.0)
-    rb-readline (0.5.5)
     rbnacl (3.4.0)
       ffi
     rbnacl-libsodium (1.0.16)
@@ -481,22 +393,16 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.15.1)
       parser (>= 3.0.1.1)
-    rubocop-faker (1.1.0)
-      faker (>= 2.12.0)
-      rubocop (>= 0.82.0)
     rubocop-rails (2.12.4)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.7.0, < 2.0)
     rubocop-rspec (2.6.0)
       rubocop (~> 1.19)
-    ruby-graphviz (1.2.5)
-      rexml
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
     ruby_parser (3.18.1)
       sexp_processor (~> 4.16)
-    rubyzip (2.3.2)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
@@ -508,13 +414,8 @@ GEM
       sprockets-rails
       tilt
     sax-machine (1.3.2)
-    selenium-webdriver (4.1.0)
-      childprocess (>= 0.5, < 5.0)
-      rexml (~> 3.2, >= 3.2.5)
-      rubyzip (>= 1.2.2)
     set (1.0.2)
     sexp_processor (4.16.0)
-    shellany (0.0.1)
     sidekiq (6.3.1)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
@@ -531,13 +432,6 @@ GEM
     sorted_set (1.0.3)
       rbtree
       set (~> 1.0)
-    spinach (0.11.0)
-      colorize
-      gherkin-ruby (>= 0.3.2)
-      json
-    spinach-console-reporter (0.0.2)
-      spinach
-    spring (3.1.1)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -551,10 +445,6 @@ GEM
       net-ssh (>= 2.8.0)
     statsd-instrument (3.1.2)
     sysexits (1.2.0)
-    teaspoon (1.2.2)
-      railties (>= 3.2.5)
-    teaspoon-jasmine (2.9.1)
-      teaspoon (>= 1.0.0)
     temple (0.8.2)
     terrapin (0.6.0)
       climate_control (>= 0.0.3, < 1.0)
@@ -592,8 +482,6 @@ GEM
     will_paginate (3.3.1)
     will_paginate-bootstrap (1.0.2)
       will_paginate (>= 3.0.3)
-    xpath (3.2.0)
-      nokogiri (~> 1.8)
 
 PLATFORMS
   x86_64-darwin-21
@@ -606,7 +494,6 @@ DEPENDENCIES
   aws-sdk (~> 2.3)
   bcrypt_pbkdf (~> 1.0)
   better_errors
-  binding_of_caller
   bootsnap (~> 1.10.3)
   brakeman (>= 4.7.1)
   bundler-audit
@@ -618,7 +505,6 @@ DEPENDENCIES
   capistrano-rails
   capistrano-rbenv (~> 2.0)
   capistrano-sidekiq
-  capybara
   clearance
   coffee-rails
   coffee-script-source (~> 1.8.0)
@@ -632,21 +518,13 @@ DEPENDENCIES
   factory_bot_rails
   faker
   feedjira
-  flog
   font-awesome-rails
-  guard
-  guard-coffeescript
-  guard-haml_lint
-  guard-livereload (~> 2.5, >= 2.5.2)
-  guard-rubocop
   haml-rails (~> 1.0)
   haml_lint (~> 0.21)
   jbuilder
   jwt
   letter_opener
   letter_opener_web
-  m (~> 1.5.0)
-  meta_request
   mini_magick (~> 4.9.4)
   minitest-rails
   minitest-spec-rails
@@ -657,37 +535,26 @@ DEPENDENCIES
   open4
   paperclip (~> 5.3)
   pg (= 0.20)
-  pry-byebug
-  pry-rails
   rails (~> 5.2, >= 5.2.6.3)
   rails-controller-testing
-  rails-erd
   rails-html-sanitizer (~> 1.3.0)
   ransack!
-  rb-readline (~> 0.5.5)
   rbnacl (~> 3.2)
   rbnacl-libsodium
   recaptcha
   redcarpet
   redis-rails (>= 5.0.2)
-  rubocop-faker
   rubocop-rails
   rubocop-rspec
-  ruby_parser
   sass-rails
-  selenium-webdriver
   sidekiq
   simplecov
   simplecov-rcov
   simplemde-rails
-  spinach
-  spinach-console-reporter
-  spring
   sprockets
   sprockets-rails
   sql_tracker
   statsd-instrument
-  teaspoon-jasmine
   therubyracer
   thor
   timecop

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,10 +158,10 @@ GEM
     database_cleaner-core (2.0.1)
     datadog_api_client (1.5.0)
       typhoeus (~> 1.0, >= 1.0.1)
-    ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+    ddtrace (0.54.2)
+      debase-ruby_core_source (<= 0.10.14)
       msgpack
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.14)
     docile (1.4.0)
     doorkeeper (4.4.3)
       railties (>= 4.2)


### PR DESCRIPTION
binding_of_caller -> Binding.of_caller is not used anywhere.
guard -> If one needs guard, they can install it individually.
meta_request -> Used for a chrome extension
flog -> Install this locally if needed. We do not need it in Gemfile.
m -> Rails 5 already provides a way to run tests by line number.
ruby_parser -> we do not use this anywhere.
spring -> raises exceptions related to autoload on running tests.
capybara, selenium, jasmine & spinach -> No integration tests right now.
pry -> Install this locally if needed. We do not need it in Gemfile.
rails-erd -> Install this locally when needed.
rb-readline -> This is not used anywhere.
rubocop-faker -> We do not call rubocop with this extension.