### PR TITLE
OTWO-6567 Replace uniq with sql distinct

### DIFF
--- a/app/controllers/oh_admin/license_permissions_controller.rb
+++ b/app/controllers/oh_admin/license_permissions_controller.rb
@@ -52,7 +52,7 @@ class OhAdmin::LicensePermissionsController < ApplicationController
   def retrieve_licenses
     @licenses = License.all
                        .joins(:license_license_permissions)
-                       .order(:name).uniq
+                       .order(:name).distinct
                        .collect { |license| [license.name, license.id] }
   end
 

--- a/app/controllers/privacy_controller.rb
+++ b/app/controllers/privacy_controller.rb
@@ -39,7 +39,7 @@ class PrivacyController < ApplicationController
                           .joins(:access_tokens)
                           .where('oauth_access_tokens.resource_owner_id' => @account.id)
                           .where('oauth_access_tokens.revoked_at' => nil)
-                          .uniq
+                          .distinct
   end
 
   def account_params

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -34,13 +34,13 @@ module DashboardHelper
     from = convert_to_datetime(from)
     to = convert_to_datetime(to) || Time.current
     projects_count = Project.active_enlistments.joins(:best_analysis)
-                            .where(analyses: { updated_on: from..to }).uniq.count
+                            .where(analyses: { updated_on: from..to }).distinct.count
     number_to_percentage((projects_count.to_f / active_projects_count) * 100, precision: 2)
   end
 
   def outdated_projects(date)
     projects_count = Project.active_enlistments.joins(:best_analysis)
-                            .where('analyses.updated_on < ?', date).uniq.count
+                            .where('analyses.updated_on < ?', date).distinct.count
     number_to_percentage((projects_count.to_f / active_projects_count) * 100, precision: 2)
   end
 
@@ -49,6 +49,6 @@ module DashboardHelper
   end
 
   def active_projects_count
-    Project.active_enlistments.uniq.count
+    Project.active_enlistments.distinct.count
   end
 end

--- a/app/models/position/hooks.rb
+++ b/app/models/position/hooks.rb
@@ -44,7 +44,7 @@ class Position::Hooks
                    .where('edits.undone' => false)
                    .where('(edits.account_id = :account_id AND undone_by IS NULL)
                             OR undone_by = :account_id', account_id: account_id)
-                   .uniq
+                   .distinct
 
     soft_delete_aliases(aliases)
   end


### PR DESCRIPTION
In Rails 4 `uniq` was an alias for `distinct`. This was removed in Rails 5. 
The code didn't break because Enumerable has a `uniq` method. So the
current logic was defaulting to Array's `uniq`.
This caused performance issues on the admin page.