### PR TITLE
OTWO-6817 Fix community forum registration link

### DIFF
--- a/app/views/enlistments/index.html.haml
+++ b/app/views/enlistments/index.html.haml
@@ -23,7 +23,7 @@
     %h4.alert-heading.nomargin= t('.alert_warn_heading')
     %p= t('.alert_warn_description1')
     = t('.alert_warn_description2')
-    = link_to t('.help_forum'), forum_url(10)
+    = link_to t('.help_forum'), 'https://community.synopsys.com/s/topic/0TO2H000000gHS1WAM/black-duck-open-hub-help'
     \.
     %p
     = t('.alert_warn_description3_html')

--- a/app/views/forums/_notice.html.haml
+++ b/app/views/forums/_notice.html.haml
@@ -8,7 +8,7 @@
     We’re excited to announce that we will be moving the Open Hub Forum to
     %a{href: "#{blog_link}"} #{blog_link}.
     Beginning immediately, users can head over,
-    %a{href: 'https://community.synopsys.com/s/login/SelfRegister'} register,
+    %a{href: 'https://community.synopsys.com/s/topic/0TO2H000000gHS1WAM/black-duck-open-hub-help'} register,
     get technical help and discuss issue pertinent to the Open Hub. Registered users can also subscribe to Open Hub announcements here.
 
   %p


### PR DESCRIPTION
Use the forum link instead of registration page.
It is hard for end users to find the forum otherwise.
Registration page is relatively easy to find.