### PR TITLE
OTWO-7608 Add docker setup for ohloh-ui

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,32 @@
+# Git
+.git
+.gitignore
+
+# Docker files (not needed inside container)
+Dockerfile*
+docker-compose*.yml
+.dockerignore
+DOCKER.md
+
+# Development/temp files
+tmp/
+log/
+.byebug_history
+.bundle
+coverage/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Test artifacts
+test/reports/
+
+# Node (if any)
+node_modules/

--- a/.env
+++ b/.env
@@ -1,3 +1,7 @@
+# Docker build settings - disable BuildKit (causes hangs with docker-compose v1)
+DOCKER_BUILDKIT=0
+COMPOSE_DOCKER_CLI_BUILD=0
+
 DB_ENCODING = SQL_ASCII
 DB_SEARCH_PATH = 'oh, fis, public'
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,159 @@
+# Docker Setup for Ohloh UI
+
+## Quick Start (Development)
+
+```bash
+# Using Makefile (recommended - handles cleanup automatically)
+make up-build    # First time: build and start all services
+make up          # Subsequent runs (no rebuild)
+
+# Or using docker-compose directly
+docker-compose -f docker-compose.dev.yml up --build
+
+# Access the app at: http://localhost:3000
+```
+
+The first run automatically:
+- Creates the database
+- Loads the schema from `db/structure.sql`
+- Starts all services
+
+## Subsequent Runs
+
+```bash
+# Just start (no rebuild needed, database persists)
+make up
+
+# Or in background
+make up-d
+```
+
+You should see "Database ready, starting application..." on subsequent runs.
+
+## Makefile Commands
+
+The Makefile provides shortcuts with automatic cleanup of stuck processes:
+
+| Command | Description |
+|---------|-------------|
+| `make up-build` | Clean, build, and start (recommended for first run) |
+| `make up` | Start services (no rebuild) |
+| `make up-d` | Start in background |
+| `make down` | Stop services |
+| `make restart` | Stop and start |
+| `make build` | Build images only |
+| `make clean` | Full cleanup (removes volumes/data) |
+| `make logs` | Follow all logs |
+| `make logs-web` | Follow web logs only |
+| `make shell` | Bash shell in web container |
+| `make console` | Rails console |
+| `make test` | Run tests |
+
+## Services and Ports
+
+| Service  | Port | Description           |
+|----------|------|-----------------------|
+| web      | 3000 | Rails application     |
+| postgres | 5432 | PostgreSQL database   |
+| redis    | 6379 | Redis (cache/sidekiq) |
+
+## Useful Commands
+
+```bash
+# View logs (or: make logs-web)
+docker-compose -f docker-compose.dev.yml logs -f web
+
+# Rails console (or: make console)
+docker-compose -f docker-compose.dev.yml exec web bundle exec rails c
+
+# Run tests (or: make test)
+docker-compose -f docker-compose.dev.yml exec web bundle exec rake test
+
+# Stop services (or: make down)
+docker-compose -f docker-compose.dev.yml down
+
+# Stop and reset database (or: make clean)
+docker-compose -f docker-compose.dev.yml down -v
+```
+
+## Reset Database
+
+To start fresh (removes all data):
+
+```bash
+docker-compose -f docker-compose.dev.yml down -v
+docker-compose -f docker-compose.dev.yml up --build
+```
+
+## Production Build
+
+```bash
+# Build production image
+docker build -f Dockerfile.prod -t ohloh-ui:latest .
+
+# Run production container
+docker run -d \
+  -p 3000:3000 \
+  -e RAILS_ENV=production \
+  -e SECRET_KEY_BASE=your_secret_key \
+  -e DB_HOST=your_db_host \
+  -e DB_NAME=your_db_name \
+  -e DB_USERNAME=your_db_user \
+  -e DB_PASSWORD=your_db_password \
+  -e REDIS_HOST=your_redis_host \
+  ohloh-ui:latest
+```
+
+## Troubleshooting
+
+### Build seems stuck at "Building web"
+
+**First, check for stuck processes** (most common cause):
+```bash
+# Kill any stuck docker build processes
+make clean-builds
+
+# Or manually:
+pkill -f "docker build.*ohloh-ui"
+pkill -f "docker-compose.*ohloh-ui.*build"
+```
+
+If no stuck processes, the initial build can take 15-20+ minutes due to gem installation. To see detailed progress:
+
+```bash
+# Build with verbose output
+docker-compose -f docker-compose.dev.yml build --progress=plain web
+```
+
+Common slow steps:
+- `bundle install` - compiles native extensions (nokogiri, pg, imagemagick)
+- Package downloads from rubygems.org
+
+If builds are consistently slow:
+1. **Increase Docker resources** - Docker Desktop → Settings → Resources → increase CPU/RAM
+2. **Check network** - slow gem downloads can cause timeouts
+3. **Note**: BuildKit is disabled by default (in `.env`) because it causes hangs with docker-compose v1
+
+### Database connection errors
+
+If you see "connection refused" errors:
+- Ensure the `db` service is healthy: `docker-compose -f docker-compose.dev.yml ps`
+- Check postgres logs: `docker-compose -f docker-compose.dev.yml logs db`
+- Try restarting: `docker-compose -f docker-compose.dev.yml restart db`
+
+### Port already in use
+
+If port 3000, 5432, or 6379 is already in use:
+```bash
+# Find what's using the port
+lsof -i :3000
+
+# Or change the port in docker-compose.dev.yml (e.g., "3001:3000")
+```
+
+## Environment Variables
+
+The docker-compose.dev.yml sets defaults for local development. For production, configure:
+- `DB_HOST`, `DB_NAME`, `DB_USERNAME`, `DB_PASSWORD` - PostgreSQL connection
+- `REDIS_HOST`, `REDIS_PORT` - Redis connection
+- `SECRET_KEY_BASE` - Rails secret (required for production)

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,62 @@
+# Dockerfile for Ohloh UI (OpenHub)
+# Ruby on Rails 6.1 application with PostgreSQL
+
+FROM ruby:3.1.7-slim-bullseye
+
+# Set environment variables
+ENV RAILS_ENV=development \
+    BUNDLE_PATH=/usr/local/bundle \
+    BUNDLE_WITHOUT=production:staging \
+    APP_HOME=/app \
+    RAILS_LOG_TO_STDOUT=true
+
+# Install PostgreSQL 14 client (to match server version) and system dependencies
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends \
+    curl \
+    gnupg2 \
+    lsb-release \
+    && echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
+    && curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg \
+    && apt-get update -qq \
+    && apt-get install -y --no-install-recommends \
+    build-essential \
+    libpq-dev \
+    postgresql-client-14 \
+    imagemagick \
+    libmagickwand-dev \
+    libsodium-dev \
+    libxml2-dev \
+    libxslt1-dev \
+    git \
+    nodejs \
+    npm \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create app directory
+WORKDIR $APP_HOME
+
+# Install bundler
+RUN gem install bundler:2.3.6
+
+# Copy Gemfile first for better layer caching
+COPY Gemfile Gemfile.lock ./
+
+# Install gems (verbose output to track progress)
+RUN bundle install --jobs 4 --retry 3 --verbose
+
+# Copy the rest of the application
+COPY . .
+
+# Copy and set entrypoint
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+# Expose port 3000 (Puma default)
+EXPOSE 3000
+
+# Use entrypoint for database setup
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+# Default command - start Puma server
+CMD ["bundle", "exec", "rails", "server", "-b", "0.0.0.0", "-p", "3000"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,52 @@
+.PHONY: build up down restart clean logs shell console test
+
+# Disable BuildKit - causes hangs with docker-compose v1
+export DOCKER_BUILDKIT=0
+
+# Development commands
+build: clean-builds
+	docker-compose -f docker-compose.dev.yml build
+
+up:
+	docker-compose -f docker-compose.dev.yml up
+
+up-build: clean-builds
+	docker-compose -f docker-compose.dev.yml up --build
+
+up-d:
+	docker-compose -f docker-compose.dev.yml up -d
+
+down:
+	docker-compose -f docker-compose.dev.yml down
+
+restart: down up
+
+# Clean up stuck build processes before building
+clean-builds:
+	@echo "Cleaning up any stuck docker build processes..."
+	@pkill -f "docker build.*ohloh-ui" 2>/dev/null || true
+	@pkill -f "docker-compose.*ohloh-ui.*build" 2>/dev/null || true
+	@docker builder prune -f 2>/dev/null || true
+
+# Full cleanup (removes volumes too)
+clean: down
+	docker-compose -f docker-compose.dev.yml down -v --remove-orphans
+	docker system prune -f
+
+# Logs
+logs:
+	docker-compose -f docker-compose.dev.yml logs -f
+
+logs-web:
+	docker-compose -f docker-compose.dev.yml logs -f web
+
+# Shell access
+shell:
+	docker-compose -f docker-compose.dev.yml exec web bash
+
+console:
+	docker-compose -f docker-compose.dev.yml exec web bundle exec rails c
+
+# Tests
+test:
+	docker-compose -f docker-compose.dev.yml exec web bundle exec rake test

--- a/Readme.md
+++ b/Readme.md
@@ -11,7 +11,7 @@ A Ruby on Rails application for the Open Hub platform.
 - [Testing](#testing)
 - [Pull Request Checks](#pull-request-checks)
 - [Contributing](#contributing)
-
+- [Running the Application using Docker](#running-the-application-docker)
 ## 🔧 Prerequisites
 
 Before you begin, ensure you have the following installed:
@@ -163,6 +163,10 @@ This includes:
 
 After all the successful checks, CI pipeline will have success message like
 `All checks has been passed`.
+
+###  Running the Application using Docker
+You can also run the application using Docker if you prefer to set up ohloh-ui locally without installing all the required packages.
+Refer to DOCKER.md for detailed instructions.
 
 ## 🤝 Contributing
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,93 @@
+version: '3.8'
+
+services:
+  db:
+    image: postgres:14-alpine
+    container_name: ohloh-postgres
+    environment:
+      POSTGRES_USER: ohloh
+      POSTGRES_PASSWORD: ohloh_password
+      POSTGRES_DB: ohloh_development
+    ports:
+      - "5433:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ohloh -d ohloh_development"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    container_name: ohloh-redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    container_name: ohloh-web
+    command: bundle exec rails server -b 0.0.0.0 -p 3000
+    volumes:
+      - .:/app
+    ports:
+      - "3000:3000"
+    environment:
+      RAILS_ENV: development
+      DB_HOST: db
+      DB_PORT: 5432
+      DB_USERNAME: ohloh
+      DB_PASSWORD: ohloh_password
+      DB_NAME: ohloh_development
+      DB_ENCODING: UTF8
+      DB_SEARCH_PATH: 'oh,fis,public'
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      URL_HOST: 'localhost:3000'
+      SKIP_SCHEMA_DUMP: 'true'
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    stdin_open: true
+    tty: true
+
+  sidekiq:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    container_name: ohloh-sidekiq
+    entrypoint: []
+    command: bundle exec sidekiq
+    volumes:
+      - .:/app
+    environment:
+      RAILS_ENV: development
+      DB_HOST: db
+      DB_PORT: 5432
+      DB_USERNAME: ohloh
+      DB_PASSWORD: ohloh_password
+      DB_NAME: ohloh_development
+      DB_ENCODING: UTF8
+      DB_SEARCH_PATH: 'oh,fis,public'
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+volumes:
+  postgres_data:
+  redis_data:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -e
+
+# Remove stale PID file if it exists
+rm -f tmp/pids/server.pid
+
+# Wait for PostgreSQL to be ready
+echo "Waiting for PostgreSQL at $DB_HOST:$DB_PORT..."
+until pg_isready -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USERNAME" -q 2>/dev/null; do
+  sleep 2
+done
+echo "PostgreSQL is ready!"
+
+export PGPASSWORD=$DB_PASSWORD
+
+# Function to check if schema is fully loaded (check if core table exists)
+schema_complete() {
+  psql -h $DB_HOST -U $DB_USERNAME -d $DB_NAME -tAc "SELECT to_regclass('oh.projects')" 2>/dev/null | grep -q "oh.projects"
+}
+
+# Function to check if database exists
+db_exists() {
+  psql -h $DB_HOST -U $DB_USERNAME -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='$DB_NAME'" 2>/dev/null | grep -q 1
+}
+
+# Check if this is first run or restart
+if db_exists && schema_complete; then
+  echo "Database ready, starting application..."
+else
+  echo "First run detected, setting up database..."
+
+  # Create database if it doesn't exist
+  if ! db_exists; then
+    echo "Creating database..."
+    bundle exec rake db:create
+  fi
+
+  # Load structure (skip invalid \restrict line if present)
+  # structure.sql already includes all migrations, no need to run db:migrate
+  echo "Loading schema from structure.sql..."
+  if head -1 db/structure.sql | grep -q '\\restrict'; then
+    tail -n +2 db/structure.sql | psql -h $DB_HOST -U $DB_USERNAME -d $DB_NAME
+  else
+    psql -h $DB_HOST -U $DB_USERNAME -d $DB_NAME < db/structure.sql
+  fi
+
+  echo "Database setup complete!"
+fi
+
+exec "$@"


### PR DESCRIPTION
Created Dockerfile and compose along with make file for developers to run ohloh-ui as docker services on local.
DOCKER.md can be referred to how to use docker command to run/stop application.
Readme.md is also updated to have reference to DOCKER.md