### PR TITLE
OTWO:7701: Added check to redirect to sessions/new page when unauthor…

### DIFF
--- a/config/initializers/letter_opener_web.rb
+++ b/config/initializers/letter_opener_web.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+Rails.application.config.to_prepare do
+  next unless defined?(LetterOpenerWeb::LettersController)
+
+  LetterOpenerWeb::LettersController.class_eval do
+    before_action :check_access
+    private
+    def check_access
+      redirect_to main_app.new_session_path if request.env[:clearance].current_user.nil?
+    end
+  end
+end

--- a/config/initializers/letter_opener_web.rb
+++ b/config/initializers/letter_opener_web.rb
@@ -5,7 +5,9 @@ Rails.application.config.to_prepare do
 
   LetterOpenerWeb::LettersController.class_eval do
     before_action :check_access
+
     private
+
     def check_access
       redirect_to main_app.new_session_path if request.env[:clearance].current_user.nil?
     end


### PR DESCRIPTION
This code secures the letter_opener_web gem in a Ruby on Rails application by enforcing authentication. 
It restricts access to the development email-preview dashboard so that only logged-in users (via the Clearance gem) can view sent emails.
Here is a step-by-step breakdown of how it works:
- [Rails.application.config.to_prepare] This callback block is executed once during initialization, and on every code reload in development mode. It ensures the security rule is safely applied even when classes are reloaded.next unless defined?
- (LetterOpenerWeb::LettersController): A safeguard to prevent the application from crashing if the LetterOpenerWeb gem isn't loaded (e.g., in a production environment where it might be omitted).
- LetterOpenerWeb::LettersController.class_eval: This dynamically opens the controller defined by the gem so you can inject your own custom behavior without modifying the gem's source files directly.
- before_action :check_access: Runs the custom check_access method before any email preview action is rendered.
- request.env[:clearance].current_user.nil?: Checks the active session to determine if a user is currently logged in via the Clearance gem.redirect_to main_app.new_session_path: If no one is logged in, the request is intercepted and redirected back to your main application's login screen.